### PR TITLE
Moved to using separate CosmosDB containers per entity

### DIFF
--- a/src/NoPlan.Infrastructure/Data/EntityTypeConfigurations/ToDoEntityTypeConfiguration.cs
+++ b/src/NoPlan.Infrastructure/Data/EntityTypeConfigurations/ToDoEntityTypeConfiguration.cs
@@ -7,8 +7,11 @@ public class ToDoEntityTypeConfiguration : IEntityTypeConfiguration<ToDo>
 {
     public void Configure(EntityTypeBuilder<ToDo> builder)
     {
+        builder.ToContainer("todos");
+        builder.HasNoDiscriminator();
         builder.HasPartitionKey(e => e.Id);
-        builder.Property(e => e.ETag)
+        builder
+            .Property(e => e.ETag)
             .IsETagConcurrency();
     }
 }


### PR DESCRIPTION
- Specified a dedicated CosmosDB container for the `ToDo` entity type
- Removed the discriminator for the `ToDo` entity type