### PR TITLE
Update to FastEndpoints v3.7.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -69,8 +69,8 @@ dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
 dotnet_naming_symbols.static_fields.applicable_kinds = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-dotnet_naming_style.static_prefix_style.required_prefix = s_
-dotnet_naming_style.static_prefix_style.capitalization = camel_case
+# dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = pascal_case
 
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,7 @@
 # NoPlan
 
 ## Deployments
+
 [![Build Status](https://dev.azure.com/thorstensauter/NoPlan/_apis/build/status/ThorstenSauter.NoPlan.CD?branchName=main)](https://dev.azure.com/thorstensauter/NoPlan/_build/latest?definitionId=16&branchName=main)
 
 ## Goals

--- a/src/NoPlan.Api/Features/ToDos/Create.cs
+++ b/src/NoPlan.Api/Features/ToDos/Create.cs
@@ -8,8 +8,14 @@ namespace NoPlan.Api.Features.ToDos;
 
 public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
 {
-    public IToDoService ToDoService { get; set; } = null!;
-    public IDateTimeProvider DateTimeProvider { get; set; } = null!;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IToDoService _toDoService;
+
+    public Create(IToDoService toDoService, IDateTimeProvider dateTimeProvider)
+    {
+        _toDoService = toDoService;
+        _dateTimeProvider = dateTimeProvider;
+    }
 
     public override void Configure()
     {
@@ -32,7 +38,7 @@ public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
 
     public override async Task HandleAsync(CreateToDoRequest req, CancellationToken ct)
     {
-        var toDo = await ToDoService.CreateAsync(MapToEntity(req));
+        var toDo = await _toDoService.CreateAsync(MapToEntity(req));
         await SendCreatedAtAsync<Get>(new { toDo.Id }, MapFromEntity(toDo), cancellation: ct);
     }
 
@@ -40,5 +46,5 @@ public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
         new() { Id = e.Id, Title = e.Title, Description = e.Description, CreatedAt = e.CreatedAt };
 
     public override ToDo MapToEntity(CreateToDoRequest r) =>
-        new() { Title = r.Title, Description = r.Description, CreatedAt = DateTimeProvider.Now(), CreatedBy = Guid.Parse(User.GetObjectId()!) };
+        new() { Title = r.Title, Description = r.Description, CreatedAt = _dateTimeProvider.Now(), CreatedBy = Guid.Parse(User.GetObjectId()!) };
 }

--- a/src/NoPlan.Api/Features/ToDos/Delete.cs
+++ b/src/NoPlan.Api/Features/ToDos/Delete.cs
@@ -7,7 +7,10 @@ namespace NoPlan.Api.Features.ToDos;
 
 public class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
 {
-    public IToDoService ToDoService { get; set; } = null!;
+    private readonly IToDoService _toDoService;
+
+    public Delete(IToDoService toDoService) =>
+        _toDoService = toDoService;
 
     public override void Configure()
     {
@@ -32,7 +35,7 @@ public class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
 
     public override async Task HandleAsync(DeleteToDoRequest req, CancellationToken ct)
     {
-        var deletedToDo = await ToDoService.DeleteAsync(req.Id);
+        var deletedToDo = await _toDoService.DeleteAsync(req.Id);
         if (deletedToDo is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/NoPlan.Api/Features/ToDos/Get.cs
+++ b/src/NoPlan.Api/Features/ToDos/Get.cs
@@ -7,7 +7,10 @@ namespace NoPlan.Api.Features.ToDos;
 
 public class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
 {
-    public IToDoService ToDoService { get; set; } = null!;
+    private readonly IToDoService _toDoService;
+
+    public Get(IToDoService toDoService) =>
+        _toDoService = toDoService;
 
     public override void Configure()
     {
@@ -32,7 +35,7 @@ public class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
 
     public override async Task HandleAsync(GetToDoRequest req, CancellationToken ct)
     {
-        var todo = await ToDoService.GetAsync(req.Id);
+        var todo = await _toDoService.GetAsync(req.Id);
         if (todo is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/NoPlan.Api/Features/ToDos/GetAll.cs
+++ b/src/NoPlan.Api/Features/ToDos/GetAll.cs
@@ -6,7 +6,10 @@ namespace NoPlan.Api.Features.ToDos;
 
 public class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerable<ToDo>>
 {
-    public IToDoService ToDoService { get; set; } = null!;
+    private readonly IToDoService _toDoService;
+
+    public GetAll(IToDoService toDoService) =>
+        _toDoService = toDoService;
 
     public override void Configure()
     {
@@ -28,7 +31,7 @@ public class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerab
     }
 
     public override async Task HandleAsync(EmptyRequest req, CancellationToken ct) =>
-        await SendAsync(MapFromEntity(await ToDoService.GetAllAsync()), cancellation: ct);
+        await SendAsync(MapFromEntity(await _toDoService.GetAllAsync()), cancellation: ct);
 
     public override ToDosResponse MapFromEntity(IEnumerable<ToDo> e) => new()
     {

--- a/src/NoPlan.Api/Features/ToDos/Update.cs
+++ b/src/NoPlan.Api/Features/ToDos/Update.cs
@@ -7,7 +7,10 @@ namespace NoPlan.Api.Features.ToDos;
 
 public class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
 {
-    public IToDoService ToDoService { get; set; } = null!;
+    private readonly IToDoService _toDoService;
+
+    public Update(IToDoService toDoService) =>
+        _toDoService = toDoService;
 
     public override void Configure()
     {
@@ -32,7 +35,7 @@ public class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
 
     public override async Task HandleAsync(UpdateToDoRequest req, CancellationToken ct)
     {
-        var updatedToDo = await ToDoService.UpdateAsync(MapToEntity(req));
+        var updatedToDo = await _toDoService.UpdateAsync(MapToEntity(req));
         if (updatedToDo is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.3" />
-    <PackageReference Include="FastEndpoints" Version="3.6.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="3.6.0" />
+    <PackageReference Include="FastEndpoints" Version="3.7.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="3.6.0" />
-    <PackageReference Include="FastEndpoints.Validation" Version="3.6.0" />
+    <PackageReference Include="FastEndpoints" Version="3.7.0" />
+    <PackageReference Include="FastEndpoints.Validation" Version="3.7.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Switched from property to constructor based dependency injection in all endpoints.

# Dependencies
- Updated `FastEndpoints` to `v3.7.0`
- Updated `FastEndpoints.Swagger` to `v3.7.0`
- Updated `FastEndpoints.Validation` to `v3.7.0.1`

# Miscellaneous
- Updated `.editorconfig` rules for static fields
- Updated formatting in `README.MD`