### PR TITLE
Made ToDos specific to a single user

### DIFF
--- a/src/NoPlan.Api/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/NoPlan.Api/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Security.Claims;
+using Microsoft.Identity.Web;
+
+namespace NoPlan.Api.Extensions;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static Guid GetId(this ClaimsPrincipal user) =>
+        Guid.TryParse(user.GetObjectId(), out var guid)
+            ? guid
+            : default;
+}

--- a/src/NoPlan.Api/Features/ToDos/Create.cs
+++ b/src/NoPlan.Api/Features/ToDos/Create.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Identity.Web;
+﻿using NoPlan.Api.Extensions;
 using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
@@ -46,5 +46,5 @@ public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
         new() { Id = e.Id, Title = e.Title, Description = e.Description, CreatedAt = e.CreatedAt };
 
     public override ToDo MapToEntity(CreateToDoRequest r) =>
-        new() { Title = r.Title, Description = r.Description, CreatedAt = _dateTimeProvider.Now(), CreatedBy = Guid.Parse(User.GetObjectId()!) };
+        new() { Title = r.Title, Description = r.Description, CreatedAt = _dateTimeProvider.Now(), CreatedBy = User.GetId() };
 }

--- a/src/NoPlan.Api/Features/ToDos/Delete.cs
+++ b/src/NoPlan.Api/Features/ToDos/Delete.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Api.Services;
+﻿using NoPlan.Api.Extensions;
+using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;
@@ -35,7 +36,7 @@ public class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
 
     public override async Task HandleAsync(DeleteToDoRequest req, CancellationToken ct)
     {
-        var deletedToDo = await _toDoService.DeleteAsync(req.Id);
+        var deletedToDo = await _toDoService.DeleteAsync(req.Id, User.GetId());
         if (deletedToDo is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/NoPlan.Api/Features/ToDos/Get.cs
+++ b/src/NoPlan.Api/Features/ToDos/Get.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Api.Services;
+﻿using NoPlan.Api.Extensions;
+using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;
@@ -35,7 +36,7 @@ public class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
 
     public override async Task HandleAsync(GetToDoRequest req, CancellationToken ct)
     {
-        var todo = await _toDoService.GetAsync(req.Id);
+        var todo = await _toDoService.GetAsync(req.Id, User.GetId());
         if (todo is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/NoPlan.Api/Features/ToDos/GetAll.cs
+++ b/src/NoPlan.Api/Features/ToDos/GetAll.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Api.Services;
+﻿using NoPlan.Api.Extensions;
+using NoPlan.Api.Services;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;
 
@@ -31,7 +32,7 @@ public class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerab
     }
 
     public override async Task HandleAsync(EmptyRequest req, CancellationToken ct) =>
-        await SendAsync(MapFromEntity(await _toDoService.GetAllAsync()), cancellation: ct);
+        await SendAsync(MapFromEntity(await _toDoService.GetAllAsync(User.GetId())), cancellation: ct);
 
     public override ToDosResponse MapFromEntity(IEnumerable<ToDo> e) => new()
     {

--- a/src/NoPlan.Api/Features/ToDos/Update.cs
+++ b/src/NoPlan.Api/Features/ToDos/Update.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Api.Services;
+﻿using NoPlan.Api.Extensions;
+using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;
@@ -49,5 +50,5 @@ public class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
         new() { Id = e.Id, Title = e.Title, Description = e.Description, CreatedAt = e.CreatedAt };
 
     public override ToDo MapToEntity(UpdateToDoRequest r) =>
-        new() { Id = r.Id, Title = r.Title, Description = r.Description };
+        new() { Id = r.Id, Title = r.Title, Description = r.Description, CreatedBy = User.GetId() };
 }

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.3" />
-    <PackageReference Include="FastEndpoints" Version="3.8.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="3.8.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.4" />
+    <PackageReference Include="FastEndpoints" Version="3.9.1" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="3.9.1" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NoPlan.Api/Services/IToDoService.cs
+++ b/src/NoPlan.Api/Services/IToDoService.cs
@@ -4,9 +4,9 @@ namespace NoPlan.Api.Services;
 
 public interface IToDoService
 {
-    Task<IEnumerable<ToDo>> GetAllAsync();
-    Task<ToDo?> GetAsync(Guid id);
+    Task<IEnumerable<ToDo>> GetAllAsync(Guid userId);
+    Task<ToDo?> GetAsync(Guid id, Guid userId);
     Task<ToDo> CreateAsync(ToDo newToDo);
     Task<ToDo?> UpdateAsync(ToDo updatedToDo);
-    Task<ToDo?> DeleteAsync(Guid id);
+    Task<ToDo?> DeleteAsync(Guid id, Guid userId);
 }

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="3.8.0" />
-    <PackageReference Include="FastEndpoints.Validation" Version="3.8.0" />
+    <PackageReference Include="FastEndpoints" Version="3.9.1" />
+    <PackageReference Include="FastEndpoints.Validation" Version="3.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoPlan.Infrastructure/Data/EntityTypeConfigurations/ToDoEntityTypeConfiguration.cs
+++ b/src/NoPlan.Infrastructure/Data/EntityTypeConfigurations/ToDoEntityTypeConfiguration.cs
@@ -7,9 +7,12 @@ public class ToDoEntityTypeConfiguration : IEntityTypeConfiguration<ToDo>
 {
     public void Configure(EntityTypeBuilder<ToDo> builder)
     {
-        builder.ToContainer("todos");
-        builder.HasNoDiscriminator();
-        builder.HasPartitionKey(e => e.Id);
+        builder
+            .ToContainer("todos")
+            .HasNoDiscriminator()
+            .HasPartitionKey(e => e.CreatedBy)
+            .HasKey(e => e.Id);
+
         builder
             .Property(e => e.ETag)
             .IsETagConcurrency();

--- a/src/NoPlan.Infrastructure/Data/PlannerContext.cs
+++ b/src/NoPlan.Infrastructure/Data/PlannerContext.cs
@@ -1,5 +1,4 @@
-﻿using NoPlan.Infrastructure.Data.EntityTypeConfigurations;
-using NoPlan.Infrastructure.Data.Models;
+﻿using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Infrastructure.Data;
 
@@ -12,5 +11,5 @@ public class PlannerContext : DbContext
     public DbSet<ToDo> ToDos { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
-        modelBuilder.ApplyConfiguration(new ToDoEntityTypeConfiguration());
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(PlannerContext).Assembly);
 }

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.2" />


### PR DESCRIPTION
This change introduces the concept of ownership for `ToDo` entities

# Changes
- Added an extension method for retrieving the user identifier from a `ClaimsPrincipal`
- Updated the endpoints to be user specific

## Adjusted entity type configuration
Made the user identifier the partition key for `ToDo` entitites

## Adjusted the `ToDoService`
Added the user identifier as a parameter where necessary to restrict interaction to `ToDo` entities owned by the calling user.

# Dependencies
- Updated `AspNetCore.HealthChecks.CosmosDb` to `v6.0.2`
- Updated `AspNetCore.HealthChecks.UI.Client` to `v6.0.4`
- Updated `FastEndpoints` to `v3.9.1`
- Updated `FastEndpoints.Swagger` to `v3.9.1`
- Updated `FastEndpoints.Validation` to `v3.9.1`