### PR TITLE
Fixed missing location header on todos create endpoint

### DIFF
--- a/src/NoPlan.Api/Features/ToDos/Create.cs
+++ b/src/NoPlan.Api/Features/ToDos/Create.cs
@@ -1,5 +1,4 @@
-﻿using NoPlan.Api.Extensions;
-using NoPlan.Api.Services;
+﻿using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;
@@ -39,7 +38,7 @@ public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
     public override async Task HandleAsync(CreateToDoRequest req, CancellationToken ct)
     {
         var toDo = await _toDoService.CreateAsync(MapToEntity(req));
-        await SendCreatedAtAsync<Get>(new { toDo.Id }, MapFromEntity(toDo), cancellation: ct);
+        await SendCreatedAtAsync("ToDos.Get", new { toDo.Id }, MapFromEntity(toDo), cancellation: ct);
     }
 
     public override ToDoResponse MapFromEntity(ToDo e) =>

--- a/src/NoPlan.Api/Features/ToDos/Delete.cs
+++ b/src/NoPlan.Api/Features/ToDos/Delete.cs
@@ -1,5 +1,4 @@
-﻿using NoPlan.Api.Extensions;
-using NoPlan.Api.Services;
+﻿using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;

--- a/src/NoPlan.Api/Features/ToDos/Get.cs
+++ b/src/NoPlan.Api/Features/ToDos/Get.cs
@@ -1,5 +1,4 @@
-﻿using NoPlan.Api.Extensions;
-using NoPlan.Api.Services;
+﻿using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;

--- a/src/NoPlan.Api/Features/ToDos/GetAll.cs
+++ b/src/NoPlan.Api/Features/ToDos/GetAll.cs
@@ -1,5 +1,4 @@
-﻿using NoPlan.Api.Extensions;
-using NoPlan.Api.Services;
+﻿using NoPlan.Api.Services;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;
 

--- a/src/NoPlan.Api/Features/ToDos/Update.cs
+++ b/src/NoPlan.Api/Features/ToDos/Update.cs
@@ -1,5 +1,4 @@
-﻿using NoPlan.Api.Extensions;
-using NoPlan.Api.Services;
+﻿using NoPlan.Api.Services;
 using NoPlan.Contracts.Requests.ToDos.V1;
 using NoPlan.Contracts.Responses.ToDos.V1;
 using NoPlan.Infrastructure.Data.Models;

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.4" />
-    <PackageReference Include="FastEndpoints" Version="3.9.1" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="3.9.1" />
+    <PackageReference Include="FastEndpoints" Version="3.10.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="3.10.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -24,6 +24,7 @@
   <ItemGroup>
     <Using Include="FastEndpoints" />
     <Using Include="FastEndpoints.Validation" />
+    <Using Include="NoPlan.Api.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -45,11 +45,7 @@ builder.Services
     .AddMicrosoftIdentityWebApiAuthentication(configuration);
 
 var app = builder.Build();
-using (var scope = app.Services.CreateScope())
-{
-    var plannerContext = scope.ServiceProvider.GetRequiredService<PlannerContext>();
-    plannerContext.Database.EnsureCreated();
-}
+EnsureDatabaseCreated(app);
 
 app.UseAzureAppConfiguration();
 app.UseRouting();
@@ -79,3 +75,10 @@ app.UseEndpoints(endpoints =>
 });
 
 app.Run();
+
+void EnsureDatabaseCreated(IHost webApplication)
+{
+    using var scope = webApplication.Services.CreateScope();
+    var plannerContext = scope.ServiceProvider.GetRequiredService<PlannerContext>();
+    plannerContext.Database.EnsureCreated();
+}

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="3.9.1" />
-    <PackageReference Include="FastEndpoints.Validation" Version="3.9.1" />
+    <PackageReference Include="FastEndpoints" Version="3.10.0" />
+    <PackageReference Include="FastEndpoints.Validation" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
# Fixes
- Fixed missing location header in HTTP response on `ToDos.Create` endpoint

# Miscellaneous
- Added global using for namespace `NoPlan.Api.Extensions`
- Extracted database initialization to its own method

# Dependencies
- Updated `FastEndpoints` to `v3.10.0`
- Updated `FastEndpoints.Swagger` to `v3.10.0`
- Updated `FastEndpoints.Validation` to `v3.10.0`
- Updated `Microsoft.EntityFrameworkCore` to `v6.0.3`
- Updated `Microsoft.EntityFrameworkCore.Cosmos` to `v6.0.3`
- Updated `Microsoft.EntityFrameworkCore.Design` to `v6.0.3`