### PR TITLE
Enriched the Serilog request logging middleware

### DIFF
--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -61,7 +61,13 @@ try
     EnsureDatabaseCreated(app);
 
     app.UseAzureAppConfiguration();
-    app.UseSerilogRequestLogging();
+    app.UseSerilogRequestLogging(options =>
+        options.EnrichDiagnosticContext = (diagnosticsContext, httpContext) =>
+        {
+            diagnosticsContext.Set("UserId", httpContext.User.GetId());
+            diagnosticsContext.Set("RequestId", httpContext.TraceIdentifier);
+        });
+
     app.UseRouting();
     app.UseAuthentication();
     app.UseAuthorization();

--- a/src/NoPlan.Api/appsettings.Development.json
+++ b/src/NoPlan.Api/appsettings.Development.json
@@ -5,7 +5,7 @@
       "Override": {
         "System": "Information",
         "Microsoft": "Information",
-        "Microsoft.AspNetCore": "Information"
+        "Microsoft.AspNetCore": "Warning"
       }
     }
   }


### PR DESCRIPTION
- Added the `UserId` and `RequestId` as properties on the `IDiagnosticsContext` on every request
- Adjusted the log level for `Microsoft.AspNetCore` in development to `Warning` in order to reduce duplicate request logging