### PR TITLE
Update to `FastEndpoints` v3.11.0

### DIFF
--- a/src/NoPlan.Api/Features/ToDos/Create.cs
+++ b/src/NoPlan.Api/Features/ToDos/Create.cs
@@ -21,7 +21,7 @@ public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
         Post("/todos");
         Version(1);
         Policies("User");
-        Describe(b => b
+        Description(b => b
             .Accepts<CreateToDoRequest>("application/json")
             .Produces<ToDoResponse>(201, "application/json")
             .WithName("ToDos.Create")

--- a/src/NoPlan.Api/Features/ToDos/Delete.cs
+++ b/src/NoPlan.Api/Features/ToDos/Delete.cs
@@ -17,7 +17,7 @@ public class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
         Delete("/todos/{Id}");
         Version(1);
         Policies("User");
-        Describe(b => b
+        Description(b => b
             .Accepts<DeleteToDoRequest>("application/json")
             .Produces<ToDoResponse>(200, "application/json")
             .ProducesProblem(404)

--- a/src/NoPlan.Api/Features/ToDos/Get.cs
+++ b/src/NoPlan.Api/Features/ToDos/Get.cs
@@ -17,7 +17,7 @@ public class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
         Get("/todos/{Id}");
         Version(1);
         Policies("User");
-        Describe(b => b
+        Description(b => b
             .Accepts<GetToDoRequest>("application/json")
             .Produces<ToDoResponse>(200, "application/json")
             .ProducesProblem(404)

--- a/src/NoPlan.Api/Features/ToDos/GetAll.cs
+++ b/src/NoPlan.Api/Features/ToDos/GetAll.cs
@@ -16,7 +16,7 @@ public class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerab
         Get("/todos");
         Version(1);
         Policies("User");
-        Describe(b => b
+        Description(b => b
             .Accepts<EmptyRequest>("application/json")
             .Produces<ToDosResponse>(200, "application/json")
             .WithName("ToDos.GetAll")

--- a/src/NoPlan.Api/Features/ToDos/Update.cs
+++ b/src/NoPlan.Api/Features/ToDos/Update.cs
@@ -17,7 +17,7 @@ public class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
         Put("/todos/{Id}");
         Version(1);
         Policies("User");
-        Describe(b => b
+        Description(b => b
             .Accepts<UpdateToDoRequest>("application/json")
             .Produces<ToDoResponse>(200, "application/json")
             .ProducesProblem(404)

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.4" />
-    <PackageReference Include="FastEndpoints" Version="3.10.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="3.10.0" />
+    <PackageReference Include="FastEndpoints" Version="3.11.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="3.11.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="3.10.0" />
-    <PackageReference Include="FastEndpoints.Validation" Version="3.10.0" />
+    <PackageReference Include="FastEndpoints" Version="3.11.0" />
+    <PackageReference Include="FastEndpoints.Validation" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Fixes
- Moved all endpoints from the now obsolete `Describe` to the new `Description` method

# Dependencies
- Updated `FastEndpoints` to `v3.11.0`
- Updated `FastEndpoints.Swagger` to `v3.11.0`
- Updated `FastEndpoints.Validation` to `v3.11.0`