### PR TITLE
Intermittent code cleanup

### DIFF
--- a/src/NoPlan.Api/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/NoPlan.Api/Extensions/ClaimsPrincipalExtensions.cs
@@ -6,7 +6,7 @@ namespace NoPlan.Api.Extensions;
 public static class ClaimsPrincipalExtensions
 {
     public static Guid GetId(this ClaimsPrincipal user) =>
-        Guid.TryParse(user.GetObjectId(), out var guid)
-            ? guid
+        Guid.TryParse(user.GetObjectId(), out var id)
+            ? id
             : default;
 }

--- a/src/NoPlan.Api/Features/V1/ToDos/Create.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Create.cs
@@ -5,7 +5,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Features.V1.ToDos;
 
-public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
+public sealed class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
 {
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly IToDoService _toDoService;

--- a/src/NoPlan.Api/Features/V1/ToDos/Create.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Create.cs
@@ -1,11 +1,9 @@
 ﻿using NoPlan.Api.Services;
-using NoPlan.Contracts.Requests.ToDos.V1;
-using NoPlan.Contracts.Requests.ToDos.V1.Tags;
-using NoPlan.Contracts.Responses.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1.Tags;
+using NoPlan.Contracts.Requests.V1.ToDos;
+using NoPlan.Contracts.Responses.V1.ToDos;
 using NoPlan.Infrastructure.Data.Models;
 
-namespace NoPlan.Api.Features.ToDos;
+namespace NoPlan.Api.Features.V1.ToDos;
 
 public class Create : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
 {

--- a/src/NoPlan.Api/Features/V1/ToDos/Delete.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Delete.cs
@@ -1,10 +1,9 @@
 ﻿using NoPlan.Api.Services;
-using NoPlan.Contracts.Requests.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1.Tags;
+using NoPlan.Contracts.Requests.V1.ToDos;
+using NoPlan.Contracts.Responses.V1.ToDos;
 using NoPlan.Infrastructure.Data.Models;
 
-namespace NoPlan.Api.Features.ToDos;
+namespace NoPlan.Api.Features.V1.ToDos;
 
 public class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
 {

--- a/src/NoPlan.Api/Features/V1/ToDos/Delete.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Delete.cs
@@ -5,7 +5,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Features.V1.ToDos;
 
-public class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
+public sealed class Delete : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
 {
     private readonly IToDoService _toDoService;
 

--- a/src/NoPlan.Api/Features/V1/ToDos/Get.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Get.cs
@@ -1,10 +1,9 @@
 ﻿using NoPlan.Api.Services;
-using NoPlan.Contracts.Requests.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1.Tags;
+using NoPlan.Contracts.Requests.V1.ToDos;
+using NoPlan.Contracts.Responses.V1.ToDos;
 using NoPlan.Infrastructure.Data.Models;
 
-namespace NoPlan.Api.Features.ToDos;
+namespace NoPlan.Api.Features.V1.ToDos;
 
 public class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
 {

--- a/src/NoPlan.Api/Features/V1/ToDos/Get.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Get.cs
@@ -5,7 +5,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Features.V1.ToDos;
 
-public class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
+public sealed class Get : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
 {
     private readonly IToDoService _toDoService;
 

--- a/src/NoPlan.Api/Features/V1/ToDos/GetAll.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/GetAll.cs
@@ -1,9 +1,8 @@
 ﻿using NoPlan.Api.Services;
-using NoPlan.Contracts.Responses.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1.Tags;
+using NoPlan.Contracts.Responses.V1.ToDos;
 using NoPlan.Infrastructure.Data.Models;
 
-namespace NoPlan.Api.Features.ToDos;
+namespace NoPlan.Api.Features.V1.ToDos;
 
 public class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerable<ToDo>>
 {

--- a/src/NoPlan.Api/Features/V1/ToDos/GetAll.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/GetAll.cs
@@ -4,7 +4,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Features.V1.ToDos;
 
-public class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerable<ToDo>>
+public sealed class GetAll : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerable<ToDo>>
 {
     private readonly IToDoService _toDoService;
 

--- a/src/NoPlan.Api/Features/V1/ToDos/Update.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Update.cs
@@ -1,11 +1,9 @@
 ﻿using NoPlan.Api.Services;
-using NoPlan.Contracts.Requests.ToDos.V1;
-using NoPlan.Contracts.Requests.ToDos.V1.Tags;
-using NoPlan.Contracts.Responses.ToDos.V1;
-using NoPlan.Contracts.Responses.ToDos.V1.Tags;
+using NoPlan.Contracts.Requests.V1.ToDos;
+using NoPlan.Contracts.Responses.V1.ToDos;
 using NoPlan.Infrastructure.Data.Models;
 
-namespace NoPlan.Api.Features.ToDos;
+namespace NoPlan.Api.Features.V1.ToDos;
 
 public class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
 {

--- a/src/NoPlan.Api/Features/V1/ToDos/Update.cs
+++ b/src/NoPlan.Api/Features/V1/ToDos/Update.cs
@@ -5,7 +5,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Features.V1.ToDos;
 
-public class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
+public sealed class Update : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
 {
     private readonly IToDoService _toDoService;
     private readonly IDateTimeProvider _dateTimeProvider;

--- a/src/NoPlan.Api/Options/AppConfigurationOptions.cs
+++ b/src/NoPlan.Api/Options/AppConfigurationOptions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Contains configuration values for connecting to Azure App Configuration.
 /// </summary>
-public class AppConfigurationOptions
+public sealed class AppConfigurationOptions
 {
     /// <summary>
     ///     The <see cref="IConfiguration" /> section name.

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Identity.Web;
 using NoPlan.Api.Options;
 using NoPlan.Api.Services;
+using NoPlan.Api.Swagger;
 using NoPlan.Contracts;
 using NoPlan.Infrastructure.Data;
 using Serilog;
@@ -42,6 +43,7 @@ try
         .AddFastEndpoints(new[] { typeof(IContractAssemblyMarker).Assembly })
         .AddSwaggerDoc(maxEndpointVersion: 1, settings: s =>
         {
+            s.SchemaNameGenerator = new ShortVersionedSchemaNameGenerator();
             s.DocumentName = "Release v1";
             s.Title = "NoPlan API";
             s.Version = "v1";

--- a/src/NoPlan.Api/Services/DateTimeProvider.cs
+++ b/src/NoPlan.Api/Services/DateTimeProvider.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Api.Services;
 
-public class DateTimeProvider : IDateTimeProvider
+public sealed class DateTimeProvider : IDateTimeProvider
 {
     public DateTime UtcNow() =>
         DateTime.UtcNow;

--- a/src/NoPlan.Api/Services/ToDoService.cs
+++ b/src/NoPlan.Api/Services/ToDoService.cs
@@ -4,7 +4,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Services;
 
-public class ToDoService : IToDoService
+public sealed class ToDoService : IToDoService
 {
     private readonly PlannerContext _context;
 

--- a/src/NoPlan.Api/Swagger/ShortVersionedSchemaNameGenerator.cs
+++ b/src/NoPlan.Api/Swagger/ShortVersionedSchemaNameGenerator.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+using NJsonSchema.Generation;
+
+namespace NoPlan.Api.Swagger;
+
+public sealed class ShortVersionedSchemaNameGenerator : ISchemaNameGenerator
+{
+    private static readonly Regex VersionPattern = new(@"^.*\.([V]\d)\..*$", RegexOptions.Compiled);
+
+    public string Generate(Type type)
+    {
+        var matcher = VersionPattern.Match(type.Namespace!);
+        return matcher.Success
+            ? $"{matcher.Groups[1].Value}-{type.Name}"
+            : type.FullName!;
+    }
+}

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/CreateTagRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/CreateTagRequest.cs
@@ -1,11 +1,11 @@
 ﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public record CreateTagRequest
+public sealed record CreateTagRequest
 {
     public string Name { get; init; } = null!;
 }
 
-public class CreateTagRequestValidator : Validator<CreateTagRequest>
+public sealed class CreateTagRequestValidator : Validator<CreateTagRequest>
 {
     public CreateTagRequestValidator() =>
         RuleFor(x => x.Name).NotEmpty().WithMessage("Tag name is required");

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/CreateTagRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/CreateTagRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace NoPlan.Contracts.Requests.ToDos.V1.Tags;
+﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
 public record CreateTagRequest
 {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/CreateToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/CreateToDoRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public record CreateToDoRequest
+public sealed record CreateToDoRequest
 {
     /// <summary>
     ///     The ToDo title. Must be at least 3 characters long.
@@ -18,7 +18,7 @@ public record CreateToDoRequest
     public HashSet<CreateTagRequest> Tags { get; init; } = new();
 }
 
-public class CreateToDoRequestValidator : Validator<CreateToDoRequest>
+public sealed class CreateToDoRequestValidator : Validator<CreateToDoRequest>
 {
     public CreateToDoRequestValidator()
     {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/CreateToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/CreateToDoRequest.cs
@@ -1,6 +1,4 @@
-﻿using NoPlan.Contracts.Requests.ToDos.V1.Tags;
-
-namespace NoPlan.Contracts.Requests.ToDos.V1;
+﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
 public record CreateToDoRequest
 {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/DeleteToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/DeleteToDoRequest.cs
@@ -2,7 +2,7 @@
 
 namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public record DeleteToDoRequest
+public sealed record DeleteToDoRequest
 {
     /// <summary>
     ///     The identifier of the ToDo object to delete.
@@ -11,7 +11,7 @@ public record DeleteToDoRequest
     public Guid Id { get; init; }
 }
 
-public class DeleteToDoRequestValidator : Validator<DeleteToDoRequest>
+public sealed class DeleteToDoRequestValidator : Validator<DeleteToDoRequest>
 {
     public DeleteToDoRequestValidator() =>
         RuleFor(x => x.Id)

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/DeleteToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/DeleteToDoRequest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 
-namespace NoPlan.Contracts.Requests.ToDos.V1;
+namespace NoPlan.Contracts.Requests.V1.ToDos;
 
 public record DeleteToDoRequest
 {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/GetToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/GetToDoRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace NoPlan.Contracts.Requests.ToDos.V1;
+﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
 public record GetToDoRequest
 {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/GetToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/GetToDoRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public record GetToDoRequest
+public sealed record GetToDoRequest
 {
     /// <summary>
     ///     The identifier of the ToDo object that is requested.
@@ -8,7 +8,7 @@ public record GetToDoRequest
     public Guid Id { get; init; }
 }
 
-public class GetToDoRequestValidator : Validator<GetToDoRequest>
+public sealed class GetToDoRequestValidator : Validator<GetToDoRequest>
 {
     public GetToDoRequestValidator() =>
         RuleFor(x => x.Id)

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateTagRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateTagRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace NoPlan.Contracts.Requests.ToDos.V1.Tags;
+﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
 public record UpdateTagRequest
 {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateTagRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateTagRequest.cs
@@ -1,11 +1,11 @@
 ﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public record UpdateTagRequest
+public sealed record UpdateTagRequest
 {
     public string Name { get; init; } = null!;
 }
 
-public class UpdateTagRequestValidator : Validator<UpdateTagRequest>
+public sealed class UpdateTagRequestValidator : Validator<UpdateTagRequest>
 {
     public UpdateTagRequestValidator() =>
         RuleFor(x => x.Name).NotEmpty().WithMessage("Tag name is required");

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateToDoRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public record UpdateToDoRequest
+public sealed record UpdateToDoRequest
 {
     /// <summary>
     ///     The identifier of the ToDo object to update.
@@ -23,7 +23,7 @@ public record UpdateToDoRequest
     public HashSet<UpdateTagRequest> Tags { get; init; } = new();
 }
 
-public class UpdateToDoRequestValidator : Validator<UpdateToDoRequest>
+public sealed class UpdateToDoRequestValidator : Validator<UpdateToDoRequest>
 {
     public UpdateToDoRequestValidator()
     {

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateToDoRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/UpdateToDoRequest.cs
@@ -1,6 +1,4 @@
-﻿using NoPlan.Contracts.Requests.ToDos.V1.Tags;
-
-namespace NoPlan.Contracts.Requests.ToDos.V1;
+﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
 public record UpdateToDoRequest
 {

--- a/src/NoPlan.Contracts/Responses/V1/ToDos/TagResponse.cs
+++ b/src/NoPlan.Contracts/Responses/V1/ToDos/TagResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Contracts.Responses.V1.ToDos;
 
-public class TagResponse
+public sealed record TagResponse
 {
     public string Name { get; set; } = null!;
     public DateTime AssignedAt { get; set; }

--- a/src/NoPlan.Contracts/Responses/V1/ToDos/TagResponse.cs
+++ b/src/NoPlan.Contracts/Responses/V1/ToDos/TagResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace NoPlan.Contracts.Responses.ToDos.V1.Tags;
+﻿namespace NoPlan.Contracts.Responses.V1.ToDos;
 
 public class TagResponse
 {

--- a/src/NoPlan.Contracts/Responses/V1/ToDos/ToDoResponse.cs
+++ b/src/NoPlan.Contracts/Responses/V1/ToDos/ToDoResponse.cs
@@ -1,6 +1,5 @@
-﻿using NoPlan.Contracts.Responses.ToDos.V1.Tags;
+﻿namespace NoPlan.Contracts.Responses.V1.ToDos;
 
-namespace NoPlan.Contracts.Responses.ToDos.V1;
 
 public record ToDoResponse
 {

--- a/src/NoPlan.Contracts/Responses/V1/ToDos/ToDoResponse.cs
+++ b/src/NoPlan.Contracts/Responses/V1/ToDos/ToDoResponse.cs
@@ -1,7 +1,6 @@
 ﻿namespace NoPlan.Contracts.Responses.V1.ToDos;
 
-
-public record ToDoResponse
+public sealed record ToDoResponse
 {
     /// <summary>
     ///     The unique identifier.

--- a/src/NoPlan.Contracts/Responses/V1/ToDos/ToDosResponse.cs
+++ b/src/NoPlan.Contracts/Responses/V1/ToDos/ToDosResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace NoPlan.Contracts.Responses.ToDos.V1;
+﻿namespace NoPlan.Contracts.Responses.V1.ToDos;
 
 public class ToDosResponse
 {

--- a/src/NoPlan.Contracts/Responses/V1/ToDos/ToDosResponse.cs
+++ b/src/NoPlan.Contracts/Responses/V1/ToDos/ToDosResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Contracts.Responses.V1.ToDos;
 
-public class ToDosResponse
+public sealed record ToDosResponse
 {
     /// <summary>
     ///     The collection of ToDo entities.

--- a/src/NoPlan.Infrastructure/Data/EntityTypeConfigurations/ToDoEntityTypeConfiguration.cs
+++ b/src/NoPlan.Infrastructure/Data/EntityTypeConfigurations/ToDoEntityTypeConfiguration.cs
@@ -3,7 +3,7 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Infrastructure.Data.EntityTypeConfigurations;
 
-public class ToDoEntityTypeConfiguration : IEntityTypeConfiguration<ToDo>
+public sealed class ToDoEntityTypeConfiguration : IEntityTypeConfiguration<ToDo>
 {
     public void Configure(EntityTypeBuilder<ToDo> builder)
     {

--- a/src/NoPlan.Infrastructure/Data/Models/Tag.cs
+++ b/src/NoPlan.Infrastructure/Data/Models/Tag.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Infrastructure.Data.Models;
 
-public class Tag
+public sealed class Tag
 {
     public string Name { get; set; } = null!;
     public DateTime AssignedAt { get; set; }
@@ -30,6 +30,6 @@ public class Tag
         // ReSharper disable once NonReadonlyMemberInGetHashCode
         Name.GetHashCode();
 
-    protected bool Equals(Tag other) =>
+    private bool Equals(Tag other) =>
         Name == other.Name;
 }

--- a/src/NoPlan.Infrastructure/Data/Models/ToDo.cs
+++ b/src/NoPlan.Infrastructure/Data/Models/ToDo.cs
@@ -1,6 +1,6 @@
 ﻿namespace NoPlan.Infrastructure.Data.Models;
 
-public class ToDo
+public sealed class ToDo
 {
     public Guid Id { get; set; }
     public string Title { get; set; } = null!;

--- a/src/NoPlan.Infrastructure/Data/PlannerContext.cs
+++ b/src/NoPlan.Infrastructure/Data/PlannerContext.cs
@@ -2,7 +2,7 @@
 
 namespace NoPlan.Infrastructure.Data;
 
-public class PlannerContext : DbContext
+public sealed class PlannerContext : DbContext
 {
     public PlannerContext(DbContextOptions<PlannerContext> options) : base(options)
     {


### PR DESCRIPTION
# Changes
- Adjusted out parameter name on `ClaimsPrincipalExtensions.GetId()`
- Adjusted namespaces to be contract version first, feature last for endpoints and contract objects
- Added swagger schema name generator for more readable and versioned schema names
- Sealed all applicable classes