### PR TITLE
Enable ready to run compilation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Azure Container Apps
+name: Build image and deploy to Azure Container Apps
 
 on:
   push:
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    name: Building the Docker image
+    name: Build the container image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the main branch
@@ -35,7 +35,7 @@ jobs:
           login-server: ${{ env.REGISTRY_URI }}
           username: ${{ secrets.AZURE_CLIENT_ID }}
           password: ${{ secrets.AZURE_CLIENT_SECRET }}
-      - name: Build and push container image to registry
+      - name: Build and push image to registry
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -44,7 +44,7 @@ jobs:
           context: .
 
   deploy:
-    name: Deployment
+    name: Deploy to Azure Container Apps
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -54,7 +54,7 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Deploy to Azure Container Apps
+      - name: Update image tag in Azure Container Apps
         uses: azure/CLI@v1
         with:
           inlineScript: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Thorsten Sauter
+Copyright (c) 2021-2022 Thorsten Sauter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/NoPlan.Api/Dockerfile
+++ b/src/NoPlan.Api/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR "/src/NoPlan.Api"
 RUN dotnet build "NoPlan.Api.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "NoPlan.Api.csproj" -c Release -o /app/publish
+RUN dotnet publish "NoPlan.Api.csproj" -c Release -r linux-x64 --no-self-contained -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>f0f988d0-f85a-41f4-b49a-e8381d732de2</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
In order to minimize startup times (relevant for cold starts in the serverless hosting of Azure Container Apps), the ReadyToRun compilation feature was enabled and the container image now publishes platform-specific using the `linux-x64` runtime identifier.

## Miscellaneous
- Updated license file to cover the current year
- Updated the naming in the deployment GitHub Action