### PR TITLE
Upgraded packages for .NET 7 Preview 5

### DIFF
--- a/src/NoPlan.Api/Extensions/ConfigurationExtensions.cs
+++ b/src/NoPlan.Api/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Options;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ConfigurationExtensions
+{
+    public static IServiceCollection AddSectionedOptions<TOptions>(this IServiceCollection services, IConfiguration configuration)
+        where TOptions : class, IOptionsSectionDefinition
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        return services.Configure<TOptions>(configuration.GetSection(TOptions.SectionName));
+    }
+}

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>f0f988d0-f85a-41f4-b49a-e8381d732de2</UserSecretsId>
@@ -17,7 +17,7 @@
     <PackageReference Include="FastEndpoints.Swagger" Version="4.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-preview.4.22229.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-preview.5.22302.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NoPlan.Api/Options/AppConfigurationOptions.cs
+++ b/src/NoPlan.Api/Options/AppConfigurationOptions.cs
@@ -1,16 +1,15 @@
-﻿namespace NoPlan.Api.Options;
+﻿using Microsoft.Extensions.Options;
+
+namespace NoPlan.Api.Options;
 
 /// <summary>
 ///     Contains configuration values for connecting to Azure App Configuration.
 /// </summary>
-public sealed class AppConfigurationOptions
+public sealed class AppConfigurationOptions : IOptionsSectionDefinition
 {
-    /// <summary>
-    ///     The <see cref="IConfiguration" /> section name.
-    /// </summary>
-    public const string SectionName = "AppConfiguration";
+    private const int DefaultRefreshInterval = 300;
 
-    private int _refreshInterval = 300;
+    private int _refreshInterval = DefaultRefreshInterval;
 
     /// <summary>
     ///     The <see cref="Uri" /> of the Azure App Configuration endpoint.
@@ -23,6 +22,8 @@ public sealed class AppConfigurationOptions
     public int RefreshInterval
     {
         get => _refreshInterval;
-        set => _refreshInterval = value <= 0 ? 300 : value;
+        set => _refreshInterval = value <= 0 ? DefaultRefreshInterval : value;
     }
+
+    public static string SectionName => "AppConfiguration";
 }

--- a/src/NoPlan.Api/Options/IOptionsSectionDefinition.cs
+++ b/src/NoPlan.Api/Options/IOptionsSectionDefinition.cs
@@ -1,0 +1,11 @@
+﻿// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Extensions.Options;
+
+public interface IOptionsSectionDefinition
+{
+    /// <summary>
+    ///     The <see cref="IConfiguration" /> section name.
+    /// </summary>
+    static abstract string SectionName { get; }
+}

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-preview.4.22229.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="7.0.0-preview.4.22229.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0-preview.4.22229.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-preview.5.22302.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="7.0.0-preview.5.22302.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0-preview.5.22301.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NoPlan.Api.Tests.Integration/NoPlan.Api.Tests.Integration.csproj
+++ b/tests/NoPlan.Api.Tests.Integration/NoPlan.Api.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/NoPlan.Api.Tests.Unit/NoPlan.Api.Tests.Unit.csproj
+++ b/tests/NoPlan.Api.Tests.Unit/NoPlan.Api.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Changes
- Moved to `LangVersion` `preview` for all projects
- Removed closure in `AddAzureAppConfiguration()` call
- Added interface for strongly typed `IOptions` with a section name
- Added a generic way of registering strongly typed `IOptions` from a section of `IConfiguration` using static abstract interface members for the section name
- Registered `AppConfigurationOptions` with dependency injection
- Added const value for default refresh interval in `AppConfigurationOptions`

## Dependencies:
- Upgraded `Microsoft.EntityFrameworkCore` to `v7.0.0-preview.5.22302.2`
- Upgraded `Microsoft.EntityFrameworkCore.Cosmos` to `v7.0.0-preview.5.22302.2`
- Upgraded `Microsoft.EntityFrameworkCore.Design` to `v7.0.0-preview.5.22302.2`
- Upgraded `Microsoft.EntityFrameworkCore.Design` to `v7.0.0-preview.5.22302.2`
- Upgraded `Microsoft.Extensions.Configuration.Binder` to `v7.0.0-preview.5.22301.12`