### PR TITLE
Updated to FastEndpoints `v4.3.0`

### DIFF
--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -13,8 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.4" />
-    <PackageReference Include="FastEndpoints" Version="4.2.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="4.2.0" />
+    <PackageReference Include="FastEndpoints" Version="4.3.0" />
+    <PackageReference Include="FastEndpoints.Generator" Version="4.3.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="4.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-preview.5.22302.2">

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Identity.Web;
 using NoPlan.Api.Options;
 using NoPlan.Api.Services;
-using NoPlan.Contracts;
 using NoPlan.Infrastructure.Data;
 using Serilog;
 
@@ -45,7 +44,7 @@ try
         }));
 
     builder.Services
-        .AddFastEndpoints(new[] { typeof(IContractAssemblyMarker).Assembly })
+        .AddFastEndpoints(options => options.SourceGeneratorDiscoveredTypes = DiscoveredTypes.All)
         .AddSwaggerDoc(maxEndpointVersion: 1, shortSchemaNames: true, settings: s =>
         {
             s.DocumentName = "Release v1";

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="4.2.0" />
+    <PackageReference Include="FastEndpoints" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes
Taking advantage of the new `FastEndpoints.Generator` package, which allows for a small reduction in startup time by moving endpoint type discovery to compile time.

## Dependencies
- Added dependency `FastEndpoints.Generator` `v4.3.0`
- Updated `FastEndpoints` to `v4.3.0`
- Updated `FastEndpoints.Swagger` to `v4.3.0`