### PR TITLE
Attempt to go secretless in deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,18 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to Azure Container Registry
-        uses: azure/docker-login@v1
+      - name: Login to Azure
+        uses: azure/login@v1
         with:
-          login-server: ${{ env.REGISTRY_URI }}
-          username: ${{ secrets.AZURE_CLIENT_ID }}
-          password: ${{ secrets.AZURE_CLIENT_SECRET }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Login to Azure Container Registry
+        run: |
+          set -euo pipefail
+          access_token=$(az account get-access-token --query accessToken -o tsv)
+          refresh_token=$(curl https://$REGISTRY_URI/oauth2/exchange -v -d "grant_type=access_token&service=$REGISTRY_URI&access_token=$access_token" | jq -r .refresh_token)
+          docker login -u 00000000-0000-0000-0000-000000000000 --password-stdin $REGISTRY_URI <<< "$refresh_token"
       - name: Build and push image to registry
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Currently using federated credentials does not work with the `azure/docker-login@v1` action. This workaround of logging in using OIDC and then retrieving an AAD token for the ACR is linked from the [issue](https://github.com/Azure/docker-login/issues/34#issuecomment-916661046).