### PR TITLE
Removed Nuget lock file use

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
       - name: Setup .NET
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: 7.0.x
           include-prerelease: true
       - name: Restore dependencies
-        run: dotnet restore --locked-mode
+        run: dotnet restore
       - name: Build
         run: dotnet build -c Release --no-restore
       - name: Test

--- a/src/NoPlan.Api/Dockerfile
+++ b/src/NoPlan.Api/Dockerfile
@@ -6,12 +6,9 @@ EXPOSE 443
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["src/NoPlan.Api/NoPlan.Api.csproj", "NoPlan.Api/"]
-COPY ["src/NoPlan.Api/packages.lock.json", "NoPlan.Api/"]
 COPY ["src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj", "NoPlan.Infrastructure/"]
-COPY ["src/NoPlan.Infrastructure/packages.lock.json", "NoPlan.Infrastructure/"]
 COPY ["src/NoPlan.Contracts/NoPlan.Contracts.csproj", "NoPlan.Contracts/"]
-COPY ["src/NoPlan.Contracts/packages.lock.json", "NoPlan.Contracts/"]
-RUN dotnet restore "NoPlan.Api/NoPlan.Api.csproj" --locked-mode
+RUN dotnet restore "NoPlan.Api/NoPlan.Api.csproj"
 COPY ["src/NoPlan.Api/", "NoPlan.Api/"]
 COPY ["src/NoPlan.Infrastructure/", "NoPlan.Infrastructure/"]
 COPY ["src/NoPlan.Contracts/", "NoPlan.Contracts/"]

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -7,7 +7,6 @@
     <UserSecretsId>f0f988d0-f85a-41f4-b49a-e8381d732de2</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishReadyToRun>true</PublishReadyToRun>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -4,7 +4,6 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NoPlan.Api.Tests.Integration/NoPlan.Api.Tests.Integration.csproj
+++ b/tests/NoPlan.Api.Tests.Integration/NoPlan.Api.Tests.Integration.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NoPlan.Api.Tests.Unit/NoPlan.Api.Tests.Unit.csproj
+++ b/tests/NoPlan.Api.Tests.Unit/NoPlan.Api.Tests.Unit.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Due to non-compatibility with automatic package upgrade systems like Renovate or Dependabot, the use of Nuget lock files is too much of a hassle for now.