### PR TITLE
Fixed SQL Server health check

### DIFF
--- a/src/NoPlan.Infrastructure/DependencyInjection.cs
+++ b/src/NoPlan.Infrastructure/DependencyInjection.cs
@@ -13,7 +13,7 @@ public static class DependencyInjection
             .AddHealthChecks()
             .AddSqlServer(
                 connectionString!,
-                "SQL Server",
+                name: "SQL Server",
                 timeout: TimeSpan.FromSeconds(15),
                 tags: new[] { "db", "sql" });
 


### PR DESCRIPTION
The old method call passed the intended health check name as the query.