### PR TITLE
Added request validation tests for all appropriate endpoints

### DIFF
--- a/src/NoPlan.Api/Endpoints/V1/ToDos/GetAllToDosEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/GetAllToDosEndpoint.cs
@@ -1,10 +1,11 @@
 ﻿using NoPlan.Api.Services;
+using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
 using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
-public sealed class GetAllToDosEndpoint : EndpointWithMapping<EmptyRequest, ToDosResponse, IEnumerable<ToDo>>
+public sealed class GetAllToDosEndpoint : EndpointWithMapping<GetAllToDosRequest, ToDosResponse, IEnumerable<ToDo>>
 {
     private readonly IToDoService _toDoService;
 
@@ -18,7 +19,7 @@ public sealed class GetAllToDosEndpoint : EndpointWithMapping<EmptyRequest, ToDo
         Policies("User");
     }
 
-    public override async Task HandleAsync(EmptyRequest req, CancellationToken ct) =>
+    public override async Task HandleAsync(GetAllToDosRequest req, CancellationToken ct) =>
         await SendAsync(MapFromEntity(await _toDoService.GetAllAsync(User.GetId(), ct)), cancellation: ct);
 
     public override ToDosResponse MapFromEntity(IEnumerable<ToDo> e) => new()

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/CreateTagRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/CreateTagRequest.cs
@@ -8,5 +8,6 @@ public sealed record CreateTagRequest
 public sealed class CreateTagRequestValidator : Validator<CreateTagRequest>
 {
     public CreateTagRequestValidator() =>
-        RuleFor(x => x.Name).NotEmpty().WithMessage("Tag name is required");
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Tag name is required");
 }

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/GetAllToDosRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/GetAllToDosRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
+
+public sealed record GetAllToDosRequest
+{
+}

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/CreateToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/CreateToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
@@ -1,0 +1,20 @@
+﻿{
+  Errors: {
+    Description: [
+      A description for the new ToDo is required
+    ],
+    Tags[0].Name: [
+      Tag name is required
+    ],
+    Tags[1].Name: [
+      Tag name is required
+    ],
+    Title: [
+      A minimum length of 3 characters is required for the title
+    ]
+  },
+  Type: https://httpstatuses.com/400,
+  Title: Validation Error,
+  Status: 400,
+  Detail: One or more validation errors occurred
+}

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/DeleteToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/DeleteToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  Errors: {
+    Id: [
+      The ToDo identifier is required
+    ]
+  },
+  Type: https://httpstatuses.com/400,
+  Title: Validation Error,
+  Status: 400,
+  Detail: One or more validation errors occurred
+}

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/DeleteToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/DeleteToDoEndpointTests.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Api.Tests.Integration.Fakers;
+﻿using Microsoft.AspNetCore.Mvc;
+using NoPlan.Api.Tests.Integration.Fakers;
 using NoPlan.Contracts.Responses.V1.ToDos;
 
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
@@ -28,6 +29,22 @@ public sealed class DeleteToDoEndpointTests : FakeRequestTest, IClassFixture<NoP
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         toDo.Should().BeEquivalentTo(createdToDo);
         await Verify(toDo);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturn400_WhenRequestIsMalformed()
+    {
+        // Arrange
+        var client = _apiFactory.CreateClient();
+        await _apiFactory.AuthenticateClientAsUserAsync(client);
+
+        // Act
+        var response = await client.DeleteAsync($"/api/v1/todos/{Guid.Empty}");
+        var problemDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await Verify(problemDetails);
     }
 
     [Fact]

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  Errors: {
+    Id: [
+      The ToDo identifier is required
+    ]
+  },
+  Type: https://httpstatuses.com/400,
+  Title: Validation Error,
+  Status: 400,
+  Detail: One or more validation errors occurred
+}

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetToDoEndpointTests.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Api.Tests.Integration.Fakers;
+﻿using Microsoft.AspNetCore.Mvc;
+using NoPlan.Api.Tests.Integration.Fakers;
 using NoPlan.Contracts.Responses.V1.ToDos;
 
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
@@ -27,6 +28,22 @@ public sealed class GetToDoEndpointTests : FakeRequestTest, IClassFixture<NoPlan
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         await Verify(toDo);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturn400_WhenRequestIsMalformed()
+    {
+        // Arrange
+        var client = _apiFactory.CreateClient();
+        await _apiFactory.AuthenticateClientAsUserAsync(client);
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/todos/{Guid.Empty}");
+        var problemDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await Verify(problemDetails);
     }
 
     [Fact]

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/UpdateToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/UpdateToDoEndpointTests.HandleAsync_ShouldReturn400_WhenRequestIsMalformed.verified.txt
@@ -1,0 +1,20 @@
+﻿{
+  Errors: {
+    Description: [
+      A description for the ToDo to update is required
+    ],
+    Tags[0].Name: [
+      Tag name is required
+    ],
+    Tags[1].Name: [
+      Tag name is required
+    ],
+    Title: [
+      A minimum length of 3 characters is required for new title
+    ]
+  },
+  Type: https://httpstatuses.com/400,
+  Title: Validation Error,
+  Status: 400,
+  Detail: One or more validation errors occurred
+}


### PR DESCRIPTION
Resolves #95.

## Changes
- Added request validation tests for all appropriate endpoints
- Replaced hard coded request with generated one in `CreateToDEndpointTests`
- Added a separate, empty request tpye for the `GetAllToDosEndpoint`