### PR TITLE
Removed the NuGet packages cache from PR validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,13 +27,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Use Nuget cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
@@ -58,8 +51,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:


### PR DESCRIPTION
Since the cache itself usually takes longer than a normal `dotnet restore`, removing the cache seems like the more favorable option for now.