### PR TITLE
Moved app configuration to push model using Event Grid and Service Bus

### DIFF
--- a/src/NoPlan.Api/Extensions/AppConfigurationExtensions.cs
+++ b/src/NoPlan.Api/Extensions/AppConfigurationExtensions.cs
@@ -1,0 +1,52 @@
+﻿using Azure.Identity;
+using Azure.Messaging.EventGrid;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
+using NoPlan.Api.Options;
+
+namespace NoPlan.Api.Extensions;
+
+public static class AppConfigurationExtensions
+{
+    private static IConfigurationRefresher Refresher = null!;
+
+    public static IConfigurationBuilder AddAzureAppConfiguration(this ConfigurationManager configuration)
+    {
+        var appConfigurationOptions = configuration.GetSection(AppConfigurationOptions.SectionName).Get<AppConfigurationOptions>()!;
+        var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+        {
+            ManagedIdentityClientId = configuration.GetValue<string>("ManagedIdentityClientId")
+        });
+
+        configuration.AddAzureAppConfiguration(options =>
+        {
+            options.Connect(appConfigurationOptions.EndPoint, credential);
+            options.ConfigureKeyVault(c => c.SetCredential(credential));
+            const string label = "prod";
+            options.Select(KeyFilter.Any, label);
+            options.ConfigureRefresh(refreshOptions =>
+            {
+                refreshOptions.SetCacheExpiration(TimeSpan.FromDays(1));
+                refreshOptions.Register("Sentinel", label, true);
+            });
+
+            Refresher = options.GetRefresher();
+        });
+
+        var serviceBusClient = new ServiceBusClient(appConfigurationOptions.ServiceBusNamespace, credential);
+        var processor = serviceBusClient.CreateProcessor(appConfigurationOptions.ServiceBusTopicName,
+            appConfigurationOptions.ServiceBusSubscriptionName, new() { AutoCompleteMessages = true, PrefetchCount = 10 });
+
+        processor.ProcessMessageAsync += MessageHandler;
+        return configuration;
+    }
+
+    private static Task MessageHandler(ProcessMessageEventArgs args)
+    {
+        var eventGridEvent = EventGridEvent.Parse(args.Message.Body);
+        eventGridEvent.TryCreatePushNotification(out var pushNotification);
+        Refresher.ProcessPushNotification(pushNotification);
+        return Task.CompletedTask;
+    }
+}

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="FastEndpoints" Version="4.4.0" />
     <PackageReference Include="FastEndpoints.Generator" Version="4.4.0" />
     <PackageReference Include="FastEndpoints.Swagger" Version="4.4.0" />

--- a/src/NoPlan.Api/Options/AppConfigurationOptions.cs
+++ b/src/NoPlan.Api/Options/AppConfigurationOptions.cs
@@ -7,30 +7,25 @@ namespace NoPlan.Api.Options;
 /// </summary>
 public sealed class AppConfigurationOptions : IOptionsSectionDefinition
 {
-    private const int DefaultRefreshInterval = 600;
-
-    private int _refreshInterval = DefaultRefreshInterval;
-
     /// <summary>
     ///     The <see cref="Uri" /> of the Azure App Configuration endpoint.
     /// </summary>
     public Uri EndPoint { get; set; } = null!;
 
     /// <summary>
+    ///     The Azure Service Bus namespace.
     /// </summary>
     public string ServiceBusNamespace { get; set; } = null!;
 
+    /// <summary>
+    ///     The name of the Azure Service Bus topic receiving App Configuration events.
+    /// </summary>
     public string ServiceBusTopicName { get; set; } = null!;
-    public string ServiceBusSubscriptionName { get; set; } = null!;
 
     /// <summary>
-    ///     The refresh interval in seconds. Defaults to 300 seconds (5 minutes) if no or an illegal value is supplied.
+    ///     The name of the Azure Service Bus subscription receiving App Configuration events.
     /// </summary>
-    public int RefreshInterval
-    {
-        get => _refreshInterval;
-        set => _refreshInterval = value <= 0 ? DefaultRefreshInterval : value;
-    }
+    public string ServiceBusSubscriptionName { get; set; } = null!;
 
     /// <inheritdoc />
     public static string SectionName => "AppConfiguration";

--- a/src/NoPlan.Api/Options/AppConfigurationOptions.cs
+++ b/src/NoPlan.Api/Options/AppConfigurationOptions.cs
@@ -17,6 +17,13 @@ public sealed class AppConfigurationOptions : IOptionsSectionDefinition
     public Uri EndPoint { get; set; } = null!;
 
     /// <summary>
+    /// </summary>
+    public string ServiceBusNamespace { get; set; } = null!;
+
+    public string ServiceBusTopicName { get; set; } = null!;
+    public string ServiceBusSubscriptionName { get; set; } = null!;
+
+    /// <summary>
     ///     The refresh interval in seconds. Defaults to 300 seconds (5 minutes) if no or an illegal value is supplied.
     /// </summary>
     public int RefreshInterval

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -3,7 +3,6 @@ using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
-using NoPlan.Api.Options;
 using NoPlan.Api.Services;
 using NoPlan.Infrastructure.Data;
 using Serilog;
@@ -18,7 +17,7 @@ try
     var configuration = builder.Configuration;
     if (builder.Environment.IsProduction())
     {
-        configuration.AddAzureAppConfiguration();
+        configuration.AddAzureAppConfiguration(builder.Services);
     }
 
     builder.Services
@@ -30,8 +29,6 @@ try
             s.Version = "v1";
         })
         .AddInfrastructure(configuration)
-        .AddSectionedOptions<AppConfigurationOptions>(configuration)
-        .AddAzureAppConfiguration()
         .AddApplicationInsightsTelemetry()
         .AddScoped<IToDoService, ToDoService>()
         .AddSingleton<IDateTimeProvider, DateTimeProvider>()

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -1,9 +1,7 @@
-using Azure.Identity;
 using FastEndpoints.Swagger;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Identity.Web;
 using NoPlan.Api.Options;
 using NoPlan.Api.Services;
@@ -20,24 +18,7 @@ try
     var configuration = builder.Configuration;
     if (builder.Environment.IsProduction())
     {
-        configuration.AddAzureAppConfiguration(options =>
-        {
-            var appConfigurationOptions = configuration.GetSection(AppConfigurationOptions.SectionName).Get<AppConfigurationOptions>();
-            var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
-            {
-                ManagedIdentityClientId = configuration.GetValue<string>("ManagedIdentityClientId")
-            });
-
-            options.Connect(appConfigurationOptions!.EndPoint, credential);
-            options.ConfigureKeyVault(c => c.SetCredential(credential));
-            const string label = "prod";
-            options.Select(KeyFilter.Any, label);
-            options.ConfigureRefresh(refreshOptions =>
-            {
-                refreshOptions.SetCacheExpiration(TimeSpan.FromSeconds(appConfigurationOptions.RefreshInterval));
-                refreshOptions.Register("Sentinel", label, true);
-            });
-        });
+        configuration.AddAzureAppConfiguration();
     }
 
     builder.Services

--- a/src/NoPlan.Api/Workers/AppConfigurationEventHandler.cs
+++ b/src/NoPlan.Api/Workers/AppConfigurationEventHandler.cs
@@ -1,0 +1,60 @@
+﻿using Azure.Messaging.EventGrid;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration.Extensions;
+using Microsoft.Extensions.Options;
+using NoPlan.Api.Options;
+
+namespace NoPlan.Api.Workers;
+
+/// <summary>
+///     A background worker service that receives events from Azure Service Bus when Azure App Configuration values change.
+/// </summary>
+public sealed class AppConfigurationEventHandler : BackgroundService
+{
+    private readonly ILogger<AppConfigurationEventHandler> _logger;
+    private readonly AppConfigurationOptions _options;
+    private readonly IConfigurationRefresher _refresher;
+    private readonly ServiceBusClient _serviceBusClient;
+
+    /// <summary>
+    ///     Creates a new instance of <see cref="AppConfigurationEventHandler" />.
+    /// </summary>
+    /// <param name="refresher">The configuration refresher used to fetch new configuration values.</param>
+    /// <param name="serviceBusClient">The service bus client.</param>
+    /// <param name="options">The app configuration options.</param>
+    /// <param name="logger">The logger.</param>
+    public AppConfigurationEventHandler(IConfigurationRefresher refresher, ServiceBusClient serviceBusClient,
+        IOptions<AppConfigurationOptions> options, ILogger<AppConfigurationEventHandler> logger)
+    {
+        _refresher = refresher;
+        _serviceBusClient = serviceBusClient;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var processor = _serviceBusClient.CreateProcessor(_options.ServiceBusTopicName, _options.ServiceBusSubscriptionName,
+            new() { AutoCompleteMessages = true, PrefetchCount = 10 });
+
+        processor.ProcessMessageAsync += MessageHandler;
+        processor.ProcessErrorAsync += ErrorHandler;
+        await processor.StartProcessingAsync(stoppingToken);
+    }
+
+    private Task ErrorHandler(ProcessErrorEventArgs arg)
+    {
+        _logger.LogError(arg.Exception, "Encountered an error when receiving App Configuration event");
+        return Task.CompletedTask;
+    }
+
+    private Task MessageHandler(ProcessMessageEventArgs args)
+    {
+        var eventGridEvent = EventGridEvent.Parse(args.Message.Body);
+        eventGridEvent.TryCreatePushNotification(out var pushNotification);
+        _refresher.ProcessPushNotification(pushNotification);
+        return Task.CompletedTask;
+    }
+}

--- a/src/NoPlan.Api/appsettings.json
+++ b/src/NoPlan.Api/appsettings.json
@@ -2,7 +2,6 @@
   "AllowedHosts": "*",
   "AppConfiguration": {
     "Endpoint": "",
-    "RefreshInterval": 600,
     "ServiceBusNamespace": "",
     "ServiceBusTopicName": "",
     "ServiceBusSubscriptionName": ""

--- a/src/NoPlan.Api/appsettings.json
+++ b/src/NoPlan.Api/appsettings.json
@@ -2,7 +2,10 @@
   "AllowedHosts": "*",
   "AppConfiguration": {
     "Endpoint": "",
-    "RefreshInterval": 600
+    "RefreshInterval": 600,
+    "ServiceBusNamespace": "",
+    "ServiceBusTopicName": "",
+    "ServiceBusSubscriptionName": ""
   },
   "AzureAd": {
     "Instance": "",

--- a/src/NoPlan.Contracts/Requests/V1/ToDos/GetAllToDosRequest.cs
+++ b/src/NoPlan.Contracts/Requests/V1/ToDos/GetAllToDosRequest.cs
@@ -1,5 +1,3 @@
 ﻿namespace NoPlan.Contracts.Requests.V1.ToDos;
 
-public sealed record GetAllToDosRequest
-{
-}
+public sealed record GetAllToDosRequest;


### PR DESCRIPTION
In order to minimize the number of requests going to Azure App Configuration and to receive changes in a more timely manner, we are moving from a polling based pull model to an event-driven push model. 

This push model is using [Azure Event Grid](https://docs.microsoft.com/en-us/azure/azure-app-configuration/concept-app-configuration-event) to push change and delete notifications to an Azure Service Bus topic and subscription.

## Changes
- Added dependency on `Azure.Messaging.ServiceBus` `v7.10.0`
- Adjusted `AppConfigurationOptions` by removing obsolete values and adding new values for Service Bus configuration
- Moved all registration relating to App Configuration to a dedicated extension method
- Added a dedicated background service for receiving app configuration change events