### PR TITLE
Add Azure Service Bus health check

### DIFF
--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="6.0.4" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="FastEndpoints" Version="4.4.0" />

--- a/src/NoPlan.Api/Workers/AppConfigurationEventHandler.cs
+++ b/src/NoPlan.Api/Workers/AppConfigurationEventHandler.cs
@@ -33,6 +33,12 @@ public sealed class AppConfigurationEventHandler : BackgroundService
         _options = options.Value;
     }
 
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Stopping app configuration handler");
+        return base.StopAsync(cancellationToken);
+    }
+
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -41,6 +47,7 @@ public sealed class AppConfigurationEventHandler : BackgroundService
 
         processor.ProcessMessageAsync += MessageHandler;
         processor.ProcessErrorAsync += ErrorHandler;
+        _logger.LogInformation("Starting app configuration handler");
         await processor.StartProcessingAsync(stoppingToken);
     }
 
@@ -53,6 +60,7 @@ public sealed class AppConfigurationEventHandler : BackgroundService
     private Task MessageHandler(ProcessMessageEventArgs args)
     {
         var eventGridEvent = EventGridEvent.Parse(args.Message.Body);
+        _logger.LogInformation("Received app configuration event of type {EventType}", eventGridEvent.EventType);
         eventGridEvent.TryCreatePushNotification(out var pushNotification);
         _refresher.ProcessPushNotification(pushNotification);
         return Task.CompletedTask;

--- a/src/NoPlan.Infrastructure/DependencyInjection.cs
+++ b/src/NoPlan.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using NoPlan.Infrastructure.Data;
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NoPlan.Infrastructure.Data;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection;
@@ -11,6 +12,7 @@ public static class DependencyInjection
             .AddHealthChecks()
             .AddSqlServer(
                 provider => provider.GetRequiredService<IConfiguration>().GetConnectionString("Default")!,
+                failureStatus: HealthStatus.Unhealthy,
                 name: "SQL Server",
                 timeout: TimeSpan.FromSeconds(15),
                 tags: new[] { "db", "sql" });


### PR DESCRIPTION
## Changes
- Added health check for Azure Service Bus topic subscription 
- Added dependency on `AspNetCore.HealthChecks.AzureServiceBus` `v6.0.4`
- Added explicit failure status to SQL Server health check
- Added more logging to the `AppConfigurationEventHandler`