### PR TITLE
Added health check publisher to Application Insights

### DIFF
--- a/src/NoPlan.Infrastructure/DependencyInjection.cs
+++ b/src/NoPlan.Infrastructure/DependencyInjection.cs
@@ -10,6 +10,7 @@ public static class DependencyInjection
     {
         services
             .AddHealthChecks()
+            .AddApplicationInsightsPublisher(saveDetailedReport: false)
             .AddSqlServer(
                 provider => provider.GetRequiredService<IConfiguration>().GetConnectionString("Default")!,
                 failureStatus: HealthStatus.Unhealthy,

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.Publisher.ApplicationInsights" Version="6.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-preview.7.22376.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-preview.7.22376.2" />


### PR DESCRIPTION
- Added dependency on `AspNetCore.HealthChecks.Publisher.ApplicationInsights` `v6.0.2`
- Registered the health check publisher