### PR TITLE
Removed path restrictions from code analysis action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,15 +3,8 @@ name: Perform code analysis using CodeQL
 on:
   push:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'load-testing/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'load-testing/**'
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This change is in accordance with the [guidance on the GitHub Docs](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#:~:text=For%20CodeQL%20code%20scanning%20workflow%20files%2C%20don%27t%20use%20the%20paths%2Dignore%20or%20paths%20keywords%20with%20the%20on%3Apush%20event%20as%20this%20is%20likely%20to%20cause%20missing%20analyses.%20For%20accurate%20results%2C%20CodeQL%20code%20scanning%20needs%20to%20be%20able%20to%20compare%20new%20changes%20with%20the%20analysis%20of%20the%20previous%20commit.).