### PR TITLE
Added own health check response writer

### DIFF
--- a/src/NoPlan.Api/HeathChecks/JsonHealthCheckResponseWriter.cs
+++ b/src/NoPlan.Api/HeathChecks/JsonHealthCheckResponseWriter.cs
@@ -7,7 +7,7 @@ namespace NoPlan.Api.HeathChecks;
 
 /// <summary>
 ///     This writer has been adapted from the existing implementation at
-///     https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.UI.Client/UIResponseWriter.cs
+///     https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/4f29f80c09e27740e242521a5e07d0b427206f43/src/HealthChecks.UI.Client/UIResponseWriter.cs
 ///     in order to drop the otherwise unnecessary dependency on the <c>AspNetCore.HealthChecks.UI.Client</c> package.
 /// </summary>
 internal static class JsonHealthCheckResponseWriter

--- a/src/NoPlan.Api/HeathChecks/JsonHealthCheckResponseWriter.cs
+++ b/src/NoPlan.Api/HeathChecks/JsonHealthCheckResponseWriter.cs
@@ -1,0 +1,93 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace NoPlan.Api.HeathChecks;
+
+/// <summary>
+///     This writer has been adapted from the existing implementation at
+///     https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.UI.Client/UIResponseWriter.cs
+///     in order to drop the otherwise unnecessary dependency on the <c>AspNetCore.HealthChecks.UI.Client</c> package.
+/// </summary>
+internal static class JsonHealthCheckResponseWriter
+{
+    private const string DefaultResponseContentType = "application/json";
+    private static readonly byte[] EmptyResponse = "{}"u8.ToArray();
+    private static readonly Lazy<JsonSerializerOptions> Options = new(CreateJsonOptions);
+
+    public static async Task WriteResponse(HttpContext httpContext, HealthReport? report)
+    {
+        if (report is null)
+        {
+            await httpContext.Response.BodyWriter.WriteAsync(EmptyResponse);
+            return;
+        }
+
+        httpContext.Response.ContentType = DefaultResponseContentType;
+        await JsonSerializer.SerializeAsync(httpContext.Response.Body, new MappedHealthReport(report), Options.Value);
+    }
+
+    private static JsonSerializerOptions CreateJsonOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            AllowTrailingCommas = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    }
+}
+
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+internal sealed class MappedHealthReport
+{
+    public MappedHealthReport(HealthReport healthReport)
+    {
+        ArgumentNullException.ThrowIfNull(healthReport);
+
+        Entries = new();
+        TotalDuration = healthReport.TotalDuration;
+        Status = healthReport.Status;
+
+        foreach (var (name, reportEntry) in healthReport.Entries)
+        {
+            var entry = new MappedHealthReportEntry
+            {
+                Data = reportEntry.Data,
+                Description = reportEntry.Description,
+                Duration = reportEntry.Duration,
+                Status = reportEntry.Status,
+                Tags = reportEntry.Tags
+            };
+
+            if (reportEntry.Exception is not null)
+            {
+                var message = reportEntry.Exception?.Message;
+                entry.Exception = message;
+                entry.Description = reportEntry.Description ?? message;
+            }
+
+            Entries.Add(name, entry);
+        }
+    }
+
+    public HealthStatus Status { get; }
+    public TimeSpan TotalDuration { get; }
+
+    // ReSharper disable once CollectionNeverQueried.Global
+    public Dictionary<string, MappedHealthReportEntry> Entries { get; }
+}
+
+internal sealed class MappedHealthReportEntry
+{
+    public required IReadOnlyDictionary<string, object>? Data { get; init; }
+    public required string? Description { get; set; }
+    public required TimeSpan Duration { get; init; }
+    public string? Exception { get; set; }
+    public required HealthStatus Status { get; init; }
+    public required IEnumerable<string>? Tags { get; init; }
+}

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="6.0.4" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="FastEndpoints" Version="4.4.0" />
     <PackageReference Include="FastEndpoints.Generator" Version="4.4.0" />

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -1,8 +1,8 @@
 using FastEndpoints.Swagger;
-using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
+using NoPlan.Api.HeathChecks;
 using NoPlan.Api.Services;
 using NoPlan.Infrastructure.Data;
 using Serilog;
@@ -93,8 +93,8 @@ try
         app.UseSwaggerUi3(s => s.ConfigureDefaults());
     }
 
-    app.MapHealthChecks("/health/ready", new() { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
-    app.MapHealthChecks("/health/live", new() { Predicate = _ => false, ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
+    app.MapHealthChecks("/health/ready", new() { ResponseWriter = JsonHealthCheckResponseWriter.WriteResponse });
+    app.MapHealthChecks("/health/live", new() { Predicate = _ => false, ResponseWriter = JsonHealthCheckResponseWriter.WriteResponse });
 
     await app.RunAsync();
 }


### PR DESCRIPTION
In order to drop the otherwise unused dependency on the `AspNetCore.HealthChecks.UI.Client` package, the implementation of the healt check response writer was integrated and adapted.

## Changes
- Added implementation of a health check response writer. It was copied and adapted from the [AspNetCore.HealthChecks.UI.Client](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/4f29f80c09e27740e242521a5e07d0b427206f43/src/HealthChecks.UI.Client/UIResponseWriter.cs) implementation.
- Removed dependency on `AspNetCore.HealthChecks.UI.Client`

