### PR TITLE
Updated `FastEndpoints` to `v5.1.1-beta`

### DIFF
--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -13,12 +13,12 @@
 
   <ItemGroup>
 
-    <PackageReference Include="FastEndpoints" Version="5.0.0" />
-    <PackageReference Include="FastEndpoints.Generator" Version="5.0.0">
+    <PackageReference Include="FastEndpoints" Version="5.1.0" />
+    <PackageReference Include="FastEndpoints.Generator" Version="5.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FastEndpoints.Swagger" Version="5.0.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-preview.7.22376.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -13,12 +13,12 @@
 
   <ItemGroup>
 
-    <PackageReference Include="FastEndpoints" Version="5.1.0" />
-    <PackageReference Include="FastEndpoints.Generator" Version="5.1.0">
+    <PackageReference Include="FastEndpoints" Version="5.1.1-beta5" />
+    <PackageReference Include="FastEndpoints.Generator" Version="5.1.1-beta5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FastEndpoints.Swagger" Version="5.1.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="5.1.1-beta5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-preview.7.22376.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="5.0.0" />
+    <PackageReference Include="FastEndpoints" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="5.1.0" />
+    <PackageReference Include="FastEndpoints" Version="5.1.1-beta5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated dependencies:
- `FastEndpoints` to `v5.1.0`
- `FastEndpoints.Generator` to `v5.1.0`
- `FastEndpoints.Swagger` to `v5.1.0`