### PR TITLE
Updated dependencies for .NET 7 RC1 release

### DIFF
--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FastEndpoints.Swagger" Version="5.1.1-beta5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-preview.7.22376.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-rc.1.22426.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-preview.7.22376.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-preview.7.22376.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0-preview.7.22375.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.1.22426.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.1.22426.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0-rc.1.22426.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NoPlan.Api.Tests.Integration/NoPlan.Api.Tests.Integration.csproj
+++ b/tests/NoPlan.Api.Tests.Integration/NoPlan.Api.Tests.Integration.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-preview.7.22376.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-rc.1.22427.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Testcontainers" Version="2.1.0" />
     <PackageReference Include="Verify.Xunit" Version="17.10.2" />


### PR DESCRIPTION
- Updated `Microsoft.AspNetCore.Mvc.Testing` to `v7.0.0-rc.1.22427.2`
- Updated `Microsoft.EntityFrameworkCore` to `v7.0.0-rc.1.22426.7`
- Updated `Microsoft.EntityFrameworkCore.Design` to `v7.0.0-rc.1.22426.7`
- Updated `Microsoft.EntityFrameworkCore.SqlServer` to `v7.0.0-rc.1.22426.7`
- Updated `Microsoft.Extensions.Configuration.Binder` to `v7.0.0-rc.1.22426.10`