### PR TITLE
Updated dependencies for .NET 7.0.1 release

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,12 +16,15 @@
     <PackageVersion Include="FastEndpoints.Swagger" Version="5.5.0" />
     <PackageVersion Include="FluentAssertions" Version="6.8.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.2.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="1.25.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
# NuGet packages

- Updated `Microsoft.AspNetCore.Mvc.Testing` to `v7.0.1`
- Updated `Microsoft.EntityFrameworkCore` to `v7.0.1`
- Updated `Microsoft.EntityFrameworkCore.Design` to `v7.0.1`
- Updated `Microsoft.EntityFrameworkCore.SqlServer` to `v7.0.1`
- Updated `Microsoft.Extensions.Configuration.Binder` to `v7.0.1`