### PR TITLE
Remove unnecessary dependency on `Microsoft.EntityFrameworkCore`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />


### PR DESCRIPTION
Since this is a transitive dependency of `Microsoft.EntityFrameworkCore.SqlServer`, this is not longer required.