### PR TITLE
Added global GitHub environment to deployment pipeline

### DIFF
--- a/.github/workflows/deploy-global-and-staging.yml
+++ b/.github/workflows/deploy-global-and-staging.yml
@@ -1,4 +1,4 @@
-﻿name: Deploy global and staging environments
+name: Deploy global and staging environments
 
 on:
   push:
@@ -39,6 +39,7 @@ jobs:
   apply-global:
     name: Apply global environment
     runs-on: ubuntu-latest
+    environment: global
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
In order to show the deployment status correctly, the deployment pipeline now uses the `global` GitHub environment.