### PR TITLE
Enabled Source Link in container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 ﻿**/.dockerignore
 **/.env
-**/.git
 **/.gitignore
 **/.project
 **/.settings
@@ -23,4 +22,7 @@
 **/values.dev.yaml
 LICENSE
 README.md
+infra/
+load-testing/
 local-development-stack/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir /rootfs \
 WORKDIR /src
 COPY . .
 RUN dotnet restore -r linux-x64 src/NoPlan.Api/NoPlan.Api.csproj
-RUN dotnet build --no-restore -c Release -r linux-x64 --no-self-contained -p:TreatWarningsAsErrors=false -p:CodeAnalysisTreatWarningsAsErrors=false src/NoPlan.Api/NoPlan.Api.csproj
+RUN dotnet build --no-restore -c Release -r linux-x64 --no-self-contained src/NoPlan.Api/NoPlan.Api.csproj
 RUN dotnet publish --no-build -c Release -r linux-x64 --no-self-contained -o /app/publish src/NoPlan.Api/NoPlan.Api.csproj
 
 FROM mcr.microsoft.com/dotnet/nightly/aspnet:7.0-jammy-chiseled AS final


### PR DESCRIPTION
In order to enable Source Link in the container image, the `.git` directory cannot be ignored in the `.dockerignore` file. This change also makes turning off warnings as errors superfluous and has therefore been removed.