### PR TITLE
Switched to using the serverless Azure SQL offering

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -16,13 +16,14 @@ resource "azurerm_mssql_firewall_rule" "firewall_rule_allow_azure_services" {
 }
 
 resource "azurerm_mssql_database" "database" {
-  name               = var.database_name
-  server_id          = azurerm_mssql_server.database_server.id
-  collation          = "SQL_Latin1_General_CP1_CI_AS"
-  license_type       = "LicenseIncluded"
-  max_size_gb        = 2
-  sku_name           = "Basic"
-  geo_backup_enabled = true
-  zone_redundant     = false
-  tags               = var.tags
+  name                        = var.database_name
+  server_id                   = azurerm_mssql_server.database_server.id
+  collation                   = "SQL_Latin1_General_CP1_CI_AS"
+  auto_pause_delay_in_minutes = 60
+  max_size_gb                 = 1
+  min_capacity                = 0.5
+  sku_name                    = "GP_S_Gen5_1"
+  geo_backup_enabled          = true
+  zone_redundant              = false
+  tags                        = var.tags
 }


### PR DESCRIPTION
Due to the experimental nature of the project, the complete system is idle most of the time and cost can be kept low by switching to the serverless offering for Azure SLQ database.