### PR TITLE
403 add azure ad applications to managed infrastructure

### DIFF
--- a/infra/global/.terraform.lock.hcl
+++ b/infra/global/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.37.0"
+  constraints = "2.37.0"
+  hashes = [
+    "h1:IqA4lBXw0boZMFO3SbrBoywQgeb8upibsoHB741+4Qs=",
+    "zh:19fafdb527f31d8c8997d43caf537e1ddcc5f90ca258ec91af48ff5d743a08ec",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:238e5e6cdd0201aec1b16e5f7dd9c0aa97c45945d4ad8074fa2199da8218d37d",
+    "zh:59ce159938df9f38f562bd207e8fc7a5b01d9f9ccedf1198874051efc660bffb",
+    "zh:6868ccfab7f442c3fa8ba7349d75730af845a498c95f1d3e591589e2859fa8c4",
+    "zh:7e71403a4fd4e6df0d7957d28a430f766fb0fe4609c957ca1a21f9a408321857",
+    "zh:8b5888fb8a6a998751be262737407213bc32a274e4016c73f12c4202aecd0f1c",
+    "zh:aa29d2f4936fc595121d7c2c9d3c6ea58144e71cf22a1c130aa5e07e93abd01c",
+    "zh:c51257fc41c9650609ab329d85200e61b3dc7639523a073179509b5dca7d16bc",
+    "zh:cdd0ff8919d4662194f2fe374e5b1cf2cbc7bfef9204ffaba24edab8ddb765bc",
+    "zh:e0a417bdef543514805e75a729c8068f07a8d721c33d37391ab0f0a74ac7f855",
+    "zh:f6cb3c11aaeaeb7e7a22babcf9c6f46d42360dd453c7c87567b130fe93872ec1",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.52.0"
   constraints = "3.52.0"
@@ -16,6 +36,18 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:gkTL1W1Tt4FSvA2QjED05cnVHTavBtibvrecdJVi+Xk=",
     "h1:mQV+P2T755IwqMnwmOs3qv+pcFYYQor7INYxUKf2Lf4=",
     "h1:wqgJTTgbMirUCoQpEZypNLOMTHYEBzRdFRbHJeQ7sk4=",
+    "zh:0c3029da7454f2fe7058939d95c458d9930842f06430cfcd0713713f3d788216",
+    "zh:826584f11eaaec7f179e85d9cc4833ec7a1d854ed4883c94317427ddfa7ffd11",
+    "zh:8fff204176ee1b08d168848d4bd7a051d7fd189688ca8b5f26eb31855ea060a6",
+    "zh:a170ebe199b93ea1f20357d848dfd0f5e50538236f09939d1a11a61dfbfded0f",
+    "zh:acea54d715186101f8a7725997578b231e4db50eea0fb9f9868ecd867008e6e6",
+    "zh:ae0f6a61677282a2f605ca9d0a74a08ae78ae2efeb372a33b9d4c7210fbbfd2c",
+    "zh:c2c2329f3864e10ee15993c1a48e79bf72d570bb6d08003038a37b73e551dbf9",
+    "zh:c7a4a117628ff0ad24e9c73f1087e9a02b8eca633b0913ee1687b0b4b5c7f377",
+    "zh:e1a290e708e7dbbde8747a98680f7a1aace97694a243ba7a11cc5c77e982e9cc",
+    "zh:e82aa1c5e8ead3087968d7f44b6f644ef3092a0d243b4b575ff8847616e290b3",
+    "zh:f4d57d3c5f3c7fe064b88151036037b7852be6bcfa661e3f4fe0fda2871006d9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 

--- a/infra/global/applications.tf
+++ b/infra/global/applications.tf
@@ -1,0 +1,103 @@
+data "azuread_application_published_app_ids" "well_known" {}
+
+data "azuread_domains" "default_domain" {
+  only_default = true
+}
+
+locals {
+  api_user_scope_id = "b2aa6d1e-e1ce-4266-b42e-84788bc676a2"
+}
+
+resource "azuread_application" "api" {
+  display_name = "NoPlan API"
+  identifier_uris = [
+    "https://noplan.thorstensauter.dev"
+  ]
+  owners = [
+    data.azuread_client_config.current.object_id
+  ]
+  sign_in_audience = "AzureADMyOrg"
+
+  feature_tags {
+    hide = true
+  }
+
+  api {
+    oauth2_permission_scope {
+      id                         = local.api_user_scope_id
+      admin_consent_description  = "Access the NoPlan API as a user"
+      admin_consent_display_name = "Access the NoPlan API as a user"
+      enabled                    = true
+      type                       = "Admin"
+      user_consent_description   = "Access the NoPlan API as a user"
+      user_consent_display_name  = "Access the NoPlan API as a user"
+      value                      = "User"
+    }
+  }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+    resource_access {
+      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["User.Read"]
+      type = "Scope"
+    }
+  }
+
+  web {
+    homepage_url = "https://noplan.thorstensauter.dev/api"
+    redirect_uris = [
+      "https://jwt.ms/",
+      "https://oauth.pstmn.io/v1/callback"
+    ]
+  }
+}
+
+resource "azuread_application" "integration_testing" {
+  display_name                   = "NoPlan Integration Testing"
+  fallback_public_client_enabled = true
+  owners = [
+    data.azuread_client_config.current.object_id
+  ]
+  sign_in_audience = "AzureADMyOrg"
+
+  feature_tags {
+    hide = true
+  }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+    resource_access {
+      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["User.Read"]
+      type = "Scope"
+    }
+  }
+
+  required_resource_access {
+    resource_app_id = azuread_application.api.application_id
+    resource_access {
+      id   = local.api_user_scope_id
+      type = "Scope"
+    }
+  }
+}
+
+resource "azuread_service_principal" "api" {
+  application_id               = azuread_application.api.application_id
+  app_role_assignment_required = false
+  owners = [
+    data.azuread_client_config.current.object_id
+  ]
+}
+
+resource "azuread_service_principal" "integration_testing" {
+  application_id               = azuread_application.integration_testing.application_id
+  app_role_assignment_required = false
+  owners = [
+    data.azuread_client_config.current.object_id
+  ]
+}
+
+resource "azuread_service_principal" "msgraph" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing   = true
+}

--- a/infra/global/main.tf
+++ b/infra/global/main.tf
@@ -1,24 +1,4 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "3.52.0"
-    }
-    tfe = {
-      source  = "hashicorp/tfe"
-      version = "~> 0.43.0"
-    }
-  }
-
-  cloud {
-    organization = "ThorstenSauter"
-    workspaces {
-      name = "NoPlan-global"
-    }
-  }
-
-  required_version = ">= 1.4.0"
-}
+data "azuread_client_config" "current" {}
 
 data "azurerm_client_config" "current" {}
 

--- a/infra/global/outputs.tf
+++ b/infra/global/outputs.tf
@@ -1,3 +1,15 @@
+output "api_application_id" {
+  value = azuread_application.api.application_id
+}
+
+output "api_audience" {
+  value = one(azuread_application.api.identifier_uris)
+}
+
+output "api_tenant_id" {
+  value = data.azuread_client_config.current.tenant_id
+}
+
 output "container_registry_id" {
   value = module.container_registry.container_registry_id
 }
@@ -8,6 +20,14 @@ output "container_registry_endpoint" {
 
 output "container_registry_name" {
   value = module.container_registry.container_registry_name
+}
+
+output "default_domain" {
+  value = data.azuread_domains.default_domain.domains.0.domain_name
+}
+
+output "integration_testing_application_id" {
+  value = azuread_application.integration_testing.application_id
 }
 
 output "subscription_id" {

--- a/infra/global/providers.tf
+++ b/infra/global/providers.tf
@@ -1,3 +1,31 @@
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.37.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.52.0"
+    }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.43.0"
+    }
+  }
+
+  cloud {
+    organization = "ThorstenSauter"
+    workspaces {
+      name = "NoPlan-global"
+    }
+  }
+
+  required_version = ">= 1.4.0"
+}
+
+provider "azuread" {}
+
 provider "azurerm" {
   storage_use_azuread = true
   features {

--- a/infra/production/.terraform.lock.hcl
+++ b/infra/production/.terraform.lock.hcl
@@ -16,6 +16,18 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:gkTL1W1Tt4FSvA2QjED05cnVHTavBtibvrecdJVi+Xk=",
     "h1:mQV+P2T755IwqMnwmOs3qv+pcFYYQor7INYxUKf2Lf4=",
     "h1:wqgJTTgbMirUCoQpEZypNLOMTHYEBzRdFRbHJeQ7sk4=",
+    "zh:0c3029da7454f2fe7058939d95c458d9930842f06430cfcd0713713f3d788216",
+    "zh:826584f11eaaec7f179e85d9cc4833ec7a1d854ed4883c94317427ddfa7ffd11",
+    "zh:8fff204176ee1b08d168848d4bd7a051d7fd189688ca8b5f26eb31855ea060a6",
+    "zh:a170ebe199b93ea1f20357d848dfd0f5e50538236f09939d1a11a61dfbfded0f",
+    "zh:acea54d715186101f8a7725997578b231e4db50eea0fb9f9868ecd867008e6e6",
+    "zh:ae0f6a61677282a2f605ca9d0a74a08ae78ae2efeb372a33b9d4c7210fbbfd2c",
+    "zh:c2c2329f3864e10ee15993c1a48e79bf72d570bb6d08003038a37b73e551dbf9",
+    "zh:c7a4a117628ff0ad24e9c73f1087e9a02b8eca633b0913ee1687b0b4b5c7f377",
+    "zh:e1a290e708e7dbbde8747a98680f7a1aace97694a243ba7a11cc5c77e982e9cc",
+    "zh:e82aa1c5e8ead3087968d7f44b6f644ef3092a0d243b4b575ff8847616e290b3",
+    "zh:f4d57d3c5f3c7fe064b88151036037b7852be6bcfa661e3f4fe0fda2871006d9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 

--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -1,25 +1,3 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "3.52.0"
-    }
-    tfe = {
-      source  = "hashicorp/tfe"
-      version = "~> 0.43.0"
-    }
-  }
-
-  cloud {
-    organization = "ThorstenSauter"
-    workspaces {
-      name = "NoPlan-production"
-    }
-  }
-
-  required_version = ">= 1.4.0"
-}
-
 data "azurerm_client_config" "current" {}
 
 data "tfe_outputs" "global" {
@@ -28,17 +6,21 @@ data "tfe_outputs" "global" {
 }
 
 locals {
+  api_application_id      = nonsensitive(data.tfe_outputs.global.values.api_application_id)
+  api_audience            = nonsensitive(data.tfe_outputs.global.values.api_audience)
+  default_domain          = nonsensitive(data.tfe_outputs.global.values.default_domain)
+  api_tenant_id           = nonsensitive(data.tfe_outputs.global.values.api_tenant_id)
   container_registry_name = nonsensitive(data.tfe_outputs.global.values.container_registry_name)
 }
 
 module "container_app" {
   source                                = "../modules/containerapp"
   application_insights_connectionstring = module.monitoring.app_insights_connection_string
-  azure_ad_audience                     = var.azure_ad_audience
-  azure_ad_client_id                    = var.azure_ad_client_id
-  azure_ad_domain                       = var.azure_ad_domain
+  azure_ad_audience                     = local.api_audience
+  azure_ad_client_id                    = local.api_application_id
+  azure_ad_domain                       = local.default_domain
   azure_ad_instance                     = var.azure_ad_instance
-  azure_ad_tenant_id                    = var.azure_ad_tenant_id
+  azure_ad_tenant_id                    = local.api_tenant_id
   default_connectionstring              = module.database.connectionstring
   container_app_environment_id          = module.containerapp_environment.container_app_environment_id
   container_app_name                    = "aca-noplan-api-${var.env}-${var.resource_id}"

--- a/infra/production/providers.tf
+++ b/infra/production/providers.tf
@@ -1,3 +1,25 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.52.0"
+    }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.43.0"
+    }
+  }
+
+  cloud {
+    organization = "ThorstenSauter"
+    workspaces {
+      name = "NoPlan-production"
+    }
+  }
+
+  required_version = ">= 1.4.0"
+}
+
 provider "azurerm" {
   storage_use_azuread = true
   features {

--- a/infra/production/variables.tf
+++ b/infra/production/variables.tf
@@ -1,26 +1,7 @@
-variable "azure_ad_audience" {
-  type        = string
-  description = "The Azure AD app registration audience."
-}
-
-variable "azure_ad_client_id" {
-  type        = string
-  description = "The Azure AD app registration client id."
-}
-
-variable "azure_ad_domain" {
-  type        = string
-  description = "The Azure AD app registration domain."
-}
-
 variable "azure_ad_instance" {
   type        = string
   description = "The Microsoft login instance."
-}
-
-variable "azure_ad_tenant_id" {
-  type        = string
-  description = "The Azure AD app registration tenant id."
+  default     = "https://login.microsoftonline.com"
 }
 
 variable "container_image" {

--- a/infra/staging/.terraform.lock.hcl
+++ b/infra/staging/.terraform.lock.hcl
@@ -16,6 +16,18 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:gkTL1W1Tt4FSvA2QjED05cnVHTavBtibvrecdJVi+Xk=",
     "h1:mQV+P2T755IwqMnwmOs3qv+pcFYYQor7INYxUKf2Lf4=",
     "h1:wqgJTTgbMirUCoQpEZypNLOMTHYEBzRdFRbHJeQ7sk4=",
+    "zh:0c3029da7454f2fe7058939d95c458d9930842f06430cfcd0713713f3d788216",
+    "zh:826584f11eaaec7f179e85d9cc4833ec7a1d854ed4883c94317427ddfa7ffd11",
+    "zh:8fff204176ee1b08d168848d4bd7a051d7fd189688ca8b5f26eb31855ea060a6",
+    "zh:a170ebe199b93ea1f20357d848dfd0f5e50538236f09939d1a11a61dfbfded0f",
+    "zh:acea54d715186101f8a7725997578b231e4db50eea0fb9f9868ecd867008e6e6",
+    "zh:ae0f6a61677282a2f605ca9d0a74a08ae78ae2efeb372a33b9d4c7210fbbfd2c",
+    "zh:c2c2329f3864e10ee15993c1a48e79bf72d570bb6d08003038a37b73e551dbf9",
+    "zh:c7a4a117628ff0ad24e9c73f1087e9a02b8eca633b0913ee1687b0b4b5c7f377",
+    "zh:e1a290e708e7dbbde8747a98680f7a1aace97694a243ba7a11cc5c77e982e9cc",
+    "zh:e82aa1c5e8ead3087968d7f44b6f644ef3092a0d243b4b575ff8847616e290b3",
+    "zh:f4d57d3c5f3c7fe064b88151036037b7852be6bcfa661e3f4fe0fda2871006d9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 

--- a/infra/staging/providers.tf
+++ b/infra/staging/providers.tf
@@ -1,3 +1,25 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.52.0"
+    }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.43.0"
+    }
+  }
+
+  cloud {
+    organization = "ThorstenSauter"
+    workspaces {
+      name = "NoPlan-staging"
+    }
+  }
+
+  required_version = ">= 1.4.0"
+}
+
 provider "azurerm" {
   storage_use_azuread = true
   features {

--- a/infra/staging/variables.tf
+++ b/infra/staging/variables.tf
@@ -1,26 +1,7 @@
-variable "azure_ad_audience" {
-  type        = string
-  description = "The Azure AD app registration audience."
-}
-
-variable "azure_ad_client_id" {
-  type        = string
-  description = "The Azure AD app registration client id."
-}
-
-variable "azure_ad_domain" {
-  type        = string
-  description = "The Azure AD app registration domain."
-}
-
 variable "azure_ad_instance" {
   type        = string
   description = "The Microsoft login instance."
-}
-
-variable "azure_ad_tenant_id" {
-  type        = string
-  description = "The Azure AD app registration tenant id."
+  default     = "https://login.microsoftonline.com"
 }
 
 variable "container_image" {


### PR DESCRIPTION
Resolves #403.

## Changes
- Added Azure AD application registrations and service principals for the API as well as integration tests
- Added appropriate outputs
- Updated `production` and `staging` environments to use the new `global` outputs

## Terraform providers
- Added `hashicorp/azuread` in `v2.37.0`
