### PR TITLE
Use `FastEndpoints` `HttpClient` extension methods for integration tests

### DIFF
--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -29,6 +29,8 @@ await ApplyMigrationsAsync<PlannerContext>(app);
 
 app.UseFastEndpoints(c =>
 {
+    c.Endpoints.RoutePrefix = "api";
+
     c.Errors.ResponseBuilder = (failures, context, status) =>
     {
         var problemDetails = new ValidationProblemDetails
@@ -46,7 +48,6 @@ app.UseFastEndpoints(c =>
         return problemDetails;
     };
 
-    c.Endpoints.RoutePrefix = "api";
     c.Versioning.Prefix = "v";
     c.Versioning.DefaultVersion = 1;
     c.Versioning.PrependToRoute = true;

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/CreateToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/CreateToDoEndpointTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using FastEndpoints;
+using Microsoft.AspNetCore.Mvc;
+using NoPlan.Api.Endpoints.V1.ToDos;
 using NoPlan.Api.Tests.Integration.TestBases;
 using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
@@ -20,12 +22,11 @@ public sealed class CreateToDoEndpointTests : FakeRequestTest
         var request = CreateRequestFaker.Generate();
 
         // Act
-        var response = await AuthenticatedClientClient.PostAsJsonAsync("/api/v1/todos", request);
-        var toDos = await response.Content.ReadFromJsonAsync<ToDoResponse>();
+        var (response, result) = await AuthenticatedClientClient.POSTAsync<CreateToDoEndpoint, CreateToDoRequest, ToDoResponse>(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        await Verify(toDos);
+        await Verify(result);
     }
 
     [Fact]
@@ -38,20 +39,21 @@ public sealed class CreateToDoEndpointTests : FakeRequestTest
         };
 
         // Act
-        var response = await AuthenticatedClientClient.PostAsJsonAsync("/api/v1/todos", request);
-        var problemDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        var (response, result) = await AuthenticatedClientClient.POSTAsync<CreateToDoEndpoint, CreateToDoRequest, ValidationProblemDetails>(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        await Verify(problemDetails);
+        await Verify(result);
     }
 
     [Fact]
     public async Task HandleAsync_ShouldReturn401_WhenUserIsNotAuthenticated()
     {
         // Arrange
+        var request = CreateRequestFaker.Generate();
+
         // Act
-        var response = await AnonymousClient.PostAsJsonAsync("/api/v1/todos", CreateRequestFaker.Generate());
+        var (response, _) = await AnonymousClient.POSTAsync<CreateToDoEndpoint, CreateToDoRequest, ToDoResponse>(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetAllToDosEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetAllToDosEndpointTests.cs
@@ -1,4 +1,7 @@
-﻿using NoPlan.Api.Tests.Integration.TestBases;
+﻿using FastEndpoints;
+using NoPlan.Api.Endpoints.V1.ToDos;
+using NoPlan.Api.Tests.Integration.TestBases;
+using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
 
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
@@ -15,28 +18,32 @@ public sealed class GetAllToDosEndpointTests : FakeRequestTest
     public async Task HandleAsync_ShouldReturn200AndToDos_WhenUserIsAuthenticated()
     {
         // Arrange
-        foreach (var request in CreateRequestFaker.Generate(3))
+        foreach (var createToDoRequest in CreateRequestFaker.Generate(3))
         {
-            await AuthenticatedClientClient.PostAsJsonAsync("/api/v1/todos", request);
+            await AuthenticatedClientClient.POSTAsync<CreateToDoEndpoint, CreateToDoRequest, ToDoResponse>(createToDoRequest);
         }
 
+        var request = new GetAllToDosRequest();
+
         // Act
-        var response = await AuthenticatedClientClient.GetAsync("/api/v1/todos");
-        var toDos = await response.Content.ReadFromJsonAsync<ToDosResponse>();
+        var (response, result) = await AuthenticatedClientClient.GETAsync<GetAllToDosEndpoint, GetAllToDosRequest, ToDosResponse>(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        await Verify(toDos);
+        await Verify(result);
     }
 
     [Fact]
     public async Task HandleAsync_ShouldReturn401_WhenUserIsNotAuthenticated()
     {
         // Arrange
+        var request = new GetAllToDosRequest();
+
         // Act
-        var response = await AnonymousClient.GetAsync("/api/v1/todos");
+        var (response, result) = await AnonymousClient.GETAsync<GetAllToDosEndpoint, GetAllToDosRequest, ToDosResponse>(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        result.Should().BeNull();
     }
 }


### PR DESCRIPTION
Moved to using the provided `HttpClient` extension methods for calling endpoints in integration tests.