### PR TITLE
Update to `FastEndpoints` `v5.10.0`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,16 +1,15 @@
 ﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <FastEndpointsVersion>5.9.0</FastEndpointsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.10" />
     <PackageVersion Include="Bogus" Version="34.0.2" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="FastEndpoints" Version="$(FastEndpointsVersion)" />
-    <PackageVersion Include="FastEndpoints.Generator" Version="$(FastEndpointsVersion)" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="$(FastEndpointsVersion)" />
+    <PackageVersion Include="FastEndpoints" Version="5.10.0" />
+    <PackageVersion Include="FastEndpoints.Generator" Version="5.10.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="5.10.0" />
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -13,11 +13,17 @@ var configuration = builder.Configuration;
 builder.AddInfrastructure();
 builder.Services
     .AddFastEndpoints(options => options.SourceGeneratorDiscoveredTypes = DiscoveredTypes.All)
-    .AddSwaggerDoc(maxEndpointVersion: 1, shortSchemaNames: true, settings: s =>
+    .SwaggerDocument(d =>
     {
-        s.DocumentName = "Release v1";
-        s.Title = "NoPlan API";
-        s.Version = "v1";
+        d.MaxEndpointVersion = 1;
+        d.ShortSchemaNames = true;
+
+        d.DocumentSettings = s =>
+        {
+            s.DocumentName = "Release v1";
+            s.Title = "NoPlan API";
+            s.Version = "v1";
+        };
     })
     .AddScoped<IToDoService, ToDoService>()
     .AddSingleton<IDateTimeProvider, DateTimeProvider>()


### PR DESCRIPTION
# Changes

- Switched to the new way of declaring Swagger documents
- Removed the common version variable for the `FastEndpoints packages` since they don't seem to be picked up by the Renovate bot when checking NuGet package upgrades

## NuGet packages

- Updated `FastEndpoints` to `v5.10.0`
- Updated `FastEndpoints.Generator` to `v5.10.0`
- Updated `FastEndpoints.Swagger` to `v5.10.0`