### PR TITLE
Replaced CodeQL autobuild with manual build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,12 +17,13 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env:
+      SOLUTION_PATH: ./NoPlan.sln
     strategy:
       fail-fast: false
       matrix:
         language:
           - "csharp"
-          - "javascript"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -34,7 +35,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+      - name: Build .NET solution
+        run: dotnet build ${{ env.SOLUTION_PATH }}
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Since the autobuild action keeps failing to build the .NET solution, building it manually should fix the issue.