### PR TITLE
Fixed environment variable for application insights

### DIFF
--- a/infra/modules/containerapp/main.tf
+++ b/infra/modules/containerapp/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_container_app" "container_app" {
         success_count_threshold = 1
       }
       env {
-        name        = "ApplicationInsights__ConnectionString"
+        name        = "APPLICATIONINSIGHTS_CONNECTION_STRING"
         secret_name = "applicationinsights-connectionstring"
       }
       env {


### PR DESCRIPTION
Since the Opentelemetry Distro does not seem to pick up the usual `ApplicationInsights:ConnectionString` value from `IConfiguration`, the environment variable has been changed to `APPLICATIONINSIGHTS_CONNECTION_STRING`.