### PR TITLE
Reduced scope of id-token acquisition permission

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,10 +7,6 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
-
 env:
   IMAGE_NAME: ${{ vars.REGISTRY_NAME }}.azurecr.io/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
 
@@ -19,6 +15,9 @@ jobs:
     name: Promote container image for production
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      id-token: write
     env:
       SOURCE_IMAGE_NAME: ${{ vars.REGISTRY_NAME }}.azurecr.io/${{ vars.IMAGE_NAME }}:${{ github.sha }}
       TARGET_IMAGE_NAME: ${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}


### PR DESCRIPTION
In accordance with the [GitHub Blog Post](https://github.blog/changelog/2023-06-15-github-actions-securing-openid-connect-oidc-token-permissions-in-reusable-workflows), the permission for acquiring an id token from GitHub
```
permissions:
  id-token: write
```
has been moved from the workflow context to the job requiring it for logging into Azure using federated authentication