### PR TITLE
Make use of primary constructors

### DIFF
--- a/src/NoPlan.Api/Endpoints/V1/ToDos/CreateToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/CreateToDoEndpoint.cs
@@ -5,17 +5,9 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
-public sealed class CreateToDoEndpoint : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
+public sealed class CreateToDoEndpoint(IToDoService toDoService, IDateTimeProvider dateTimeProvider)
+    : EndpointWithMapping<CreateToDoRequest, ToDoResponse, ToDo>
 {
-    private readonly IDateTimeProvider _dateTimeProvider;
-    private readonly IToDoService _toDoService;
-
-    public CreateToDoEndpoint(IToDoService toDoService, IDateTimeProvider dateTimeProvider)
-    {
-        _toDoService = toDoService;
-        _dateTimeProvider = dateTimeProvider;
-    }
-
     public override void Configure()
     {
         Post("/todos");
@@ -25,7 +17,7 @@ public sealed class CreateToDoEndpoint : EndpointWithMapping<CreateToDoRequest, 
 
     public override async Task HandleAsync(CreateToDoRequest req, CancellationToken ct)
     {
-        var toDo = await _toDoService.CreateAsync(MapToEntity(req));
+        var toDo = await toDoService.CreateAsync(MapToEntity(req));
         await SendCreatedAtAsync("ToDos.Get", new { toDo.Id }, MapFromEntity(toDo), cancellation: ct);
     }
 
@@ -46,7 +38,8 @@ public sealed class CreateToDoEndpoint : EndpointWithMapping<CreateToDoRequest, 
     public override ToDo MapToEntity(CreateToDoRequest r)
     {
         ArgumentNullException.ThrowIfNull(r);
-        var creationTime = _dateTimeProvider.UtcNow();
+
+        var creationTime = dateTimeProvider.UtcNow();
         return new()
         {
             Title = r.Title,

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/DeleteToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/DeleteToDoEndpoint.cs
@@ -5,13 +5,8 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
-public sealed class DeleteToDoEndpoint : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
+public sealed class DeleteToDoEndpoint(IToDoService toDoService) : EndpointWithMapping<DeleteToDoRequest, ToDoResponse, ToDo>
 {
-    private readonly IToDoService _toDoService;
-
-    public DeleteToDoEndpoint(IToDoService toDoService) =>
-        _toDoService = toDoService;
-
     public override void Configure()
     {
         Delete("/todos/{Id}");
@@ -23,7 +18,7 @@ public sealed class DeleteToDoEndpoint : EndpointWithMapping<DeleteToDoRequest, 
     {
         ArgumentNullException.ThrowIfNull(req);
 
-        var deletedToDo = await _toDoService.DeleteAsync(req.Id, User.GetId());
+        var deletedToDo = await toDoService.DeleteAsync(req.Id, User.GetId());
         if (deletedToDo is null)
         {
             await SendNotFoundAsync(ct);
@@ -36,6 +31,7 @@ public sealed class DeleteToDoEndpoint : EndpointWithMapping<DeleteToDoRequest, 
     public override ToDoResponse MapFromEntity(ToDo e)
     {
         ArgumentNullException.ThrowIfNull(e);
+
         return new()
         {
             Id = e.Id,

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/GetAllToDosEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/GetAllToDosEndpoint.cs
@@ -5,13 +5,8 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
-public sealed class GetAllToDosEndpoint : EndpointWithMapping<GetAllToDosRequest, ToDosResponse, IEnumerable<ToDo>>
+public sealed class GetAllToDosEndpoint(IToDoService toDoService) : EndpointWithMapping<GetAllToDosRequest, ToDosResponse, IEnumerable<ToDo>>
 {
-    private readonly IToDoService _toDoService;
-
-    public GetAllToDosEndpoint(IToDoService toDoService) =>
-        _toDoService = toDoService;
-
     public override void Configure()
     {
         Get("/todos");
@@ -20,7 +15,7 @@ public sealed class GetAllToDosEndpoint : EndpointWithMapping<GetAllToDosRequest
     }
 
     public override async Task HandleAsync(GetAllToDosRequest req, CancellationToken ct) =>
-        await SendAsync(MapFromEntity(await _toDoService.GetAllAsync(User.GetId(), ct)), cancellation: ct);
+        await SendAsync(MapFromEntity(await toDoService.GetAllAsync(User.GetId(), ct)), cancellation: ct);
 
     public override ToDosResponse MapFromEntity(IEnumerable<ToDo> e) => new()
     {

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/GetToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/GetToDoEndpoint.cs
@@ -5,13 +5,8 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
-public sealed class GetToDoEndpoint : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
+public sealed class GetToDoEndpoint(IToDoService toDoService) : EndpointWithMapping<GetToDoRequest, ToDoResponse, ToDo>
 {
-    private readonly IToDoService _toDoService;
-
-    public GetToDoEndpoint(IToDoService toDoService) =>
-        _toDoService = toDoService;
-
     public override void Configure()
     {
         Get("/todos/{Id}");
@@ -24,7 +19,7 @@ public sealed class GetToDoEndpoint : EndpointWithMapping<GetToDoRequest, ToDoRe
     {
         ArgumentNullException.ThrowIfNull(req);
 
-        var todo = await _toDoService.GetAsync(req.Id, User.GetId(), ct);
+        var todo = await toDoService.GetAsync(req.Id, User.GetId(), ct);
         if (todo is null)
         {
             await SendNotFoundAsync(ct);

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/UpdateToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/UpdateToDoEndpoint.cs
@@ -5,17 +5,9 @@ using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
-public sealed class UpdateToDoEndpoint : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
+public sealed class UpdateToDoEndpoint(IToDoService toDoService, IDateTimeProvider dateTimeProvider)
+    : EndpointWithMapping<UpdateToDoRequest, ToDoResponse, ToDo>
 {
-    private readonly IToDoService _toDoService;
-    private readonly IDateTimeProvider _dateTimeProvider;
-
-    public UpdateToDoEndpoint(IToDoService toDoService, IDateTimeProvider dateTimeProvider)
-    {
-        _toDoService = toDoService;
-        _dateTimeProvider = dateTimeProvider;
-    }
-
     public override void Configure()
     {
         Put("/todos/{Id}");
@@ -25,7 +17,7 @@ public sealed class UpdateToDoEndpoint : EndpointWithMapping<UpdateToDoRequest, 
 
     public override async Task HandleAsync(UpdateToDoRequest req, CancellationToken ct)
     {
-        var updatedToDo = await _toDoService.UpdateAsync(MapToEntity(req));
+        var updatedToDo = await toDoService.UpdateAsync(MapToEntity(req));
         if (updatedToDo is null)
         {
             await SendNotFoundAsync(ct);
@@ -52,7 +44,7 @@ public sealed class UpdateToDoEndpoint : EndpointWithMapping<UpdateToDoRequest, 
     public override ToDo MapToEntity(UpdateToDoRequest r)
     {
         ArgumentNullException.ThrowIfNull(r);
-        var updateTime = _dateTimeProvider.UtcNow();
+        var updateTime = dateTimeProvider.UtcNow();
         return new()
         {
             Id = r.Id,

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -74,6 +74,6 @@ static async Task ApplyMigrationsAsync<T>(IHost webApplication)
     where T : DbContext
 {
     using var scope = webApplication.Services.CreateScope();
-    var plannerContext = scope.ServiceProvider.GetRequiredService<T>();
-    await plannerContext.Database.MigrateAsync();
+    var dbContext = scope.ServiceProvider.GetRequiredService<T>();
+    await dbContext.Database.MigrateAsync();
 }

--- a/src/NoPlan.Api/Services/ToDoService.cs
+++ b/src/NoPlan.Api/Services/ToDoService.cs
@@ -7,24 +7,19 @@ namespace NoPlan.Api.Services;
 /// <summary>
 ///     Implements the <see cref="IToDoService" /> using Entity Framework Cores <see cref="PlannerContext" />.
 /// </summary>
-public sealed class ToDoService : IToDoService
+/// <remarks>
+///     Initializes a new instance of the <see cref="ToDoService" /> class.
+/// </remarks>
+/// <param name="context">The <see cref="DbContext" /> to use for data access.</param>
+public sealed class ToDoService(PlannerContext context) : IToDoService
 {
-    private readonly PlannerContext _context;
-
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="ToDoService" /> class.
-    /// </summary>
-    /// <param name="context">The <see cref="DbContext" /> to use for data access.</param>
-    public ToDoService(PlannerContext context) =>
-        _context = context;
-
     /// <inheritdoc />
     public async Task<IEnumerable<ToDo>> GetAllAsync(Guid userId, CancellationToken cancellationToken = default) =>
-        await _context.ToDos.Include(t => t.Tags).OrderByDescending(t => t.CreatedAt).AsNoTracking().ToListAsync(cancellationToken);
+        await context.ToDos.Include(t => t.Tags).OrderByDescending(t => t.CreatedAt).AsNoTracking().ToListAsync(cancellationToken);
 
     /// <inheritdoc />
     public async Task<ToDo?> GetAsync(Guid id, Guid userId, CancellationToken cancellationToken = default) =>
-        await _context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        await context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
 
     /// <inheritdoc />
     public async Task<ToDo> CreateAsync(ToDo newToDo)
@@ -32,8 +27,8 @@ public sealed class ToDoService : IToDoService
         ArgumentNullException.ThrowIfNull(newToDo);
 
         newToDo.Id = Guid.NewGuid();
-        await _context.ToDos.AddAsync(newToDo);
-        await _context.SaveChangesAsync();
+        await context.ToDos.AddAsync(newToDo);
+        await context.SaveChangesAsync();
         return newToDo;
     }
 
@@ -42,7 +37,7 @@ public sealed class ToDoService : IToDoService
     {
         ArgumentNullException.ThrowIfNull(updatedToDo);
 
-        var toDo = await _context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == updatedToDo.Id);
+        var toDo = await context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == updatedToDo.Id);
         if (toDo is null)
         {
             return null;
@@ -60,21 +55,21 @@ public sealed class ToDoService : IToDoService
         toDo.Title = updatedToDo.Title;
         toDo.Description = updatedToDo.Description;
         toDo.Tags = updatedToDo.Tags;
-        await _context.SaveChangesAsync();
+        await context.SaveChangesAsync();
         return toDo;
     }
 
     /// <inheritdoc />
     public async Task<ToDo?> DeleteAsync(Guid id, Guid userId)
     {
-        var toDo = await _context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == id);
+        var toDo = await context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == id);
         if (toDo is null)
         {
             return null;
         }
 
-        _context.ToDos.Remove(toDo);
-        await _context.SaveChangesAsync();
+        context.ToDos.Remove(toDo);
+        await context.SaveChangesAsync();
         return toDo;
     }
 }

--- a/src/NoPlan.Infrastructure/Data/PlannerContext.cs
+++ b/src/NoPlan.Infrastructure/Data/PlannerContext.cs
@@ -2,14 +2,9 @@
 
 namespace NoPlan.Infrastructure.Data;
 
-public sealed class PlannerContext : DbContext
+public sealed class PlannerContext(DbContextOptions<PlannerContext> options) : DbContext(options)
 {
-    public PlannerContext(DbContextOptions<PlannerContext> options)
-        : base(options)
-    {
-    }
-
-    public DbSet<ToDo> ToDos { get; set; } = null!;
+    public required DbSet<ToDo> ToDos { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/tests/NoPlan.Api.Tests.Integration/AsyncLazy.cs
+++ b/tests/NoPlan.Api.Tests.Integration/AsyncLazy.cs
@@ -1,9 +1,3 @@
 ﻿namespace NoPlan.Api.Tests.Integration;
 
-public sealed class AsyncLazy<T> : Lazy<Task<T>>
-{
-    public AsyncLazy(Func<Task<T>> taskFactory) :
-        base(() => Task.Factory.StartNew(taskFactory).Unwrap())
-    {
-    }
-}
+public sealed class AsyncLazy<T>(Func<Task<T>> taskFactory) : Lazy<Task<T>>(() => Task.Factory.StartNew(taskFactory).Unwrap());

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/CreateToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/CreateToDoEndpointTests.cs
@@ -8,13 +8,8 @@ using NoPlan.Contracts.Responses.V1.ToDos;
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
 
 [UsesVerify]
-public sealed class CreateToDoEndpointTests : FakeRequestTest
+public sealed class CreateToDoEndpointTests(NoPlanApiFactory factory) : FakeRequestTest(factory)
 {
-    public CreateToDoEndpointTests(NoPlanApiFactory factory)
-        : base(factory)
-    {
-    }
-
     [Fact]
     public async Task HandleAsync_ShouldReturn201AndToDo_WhenRequestIsValidAndUserIsAuthenticated()
     {

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/DeleteToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/DeleteToDoEndpointTests.cs
@@ -8,13 +8,8 @@ using NoPlan.Contracts.Responses.V1.ToDos;
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
 
 [UsesVerify]
-public sealed class DeleteToDoEndpointTests : FakeRequestTest
+public sealed class DeleteToDoEndpointTests(NoPlanApiFactory factory) : FakeRequestTest(factory)
 {
-    public DeleteToDoEndpointTests(NoPlanApiFactory factory)
-        : base(factory)
-    {
-    }
-
     [Fact]
     public async Task HandleAsync_ShouldReturn204AndToDo_WhenToDoExistsAndUserIsAuthenticated()
     {

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetAllToDosEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetAllToDosEndpointTests.cs
@@ -7,13 +7,8 @@ using NoPlan.Contracts.Responses.V1.ToDos;
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
 
 [UsesVerify]
-public sealed class GetAllToDosEndpointTests : FakeRequestTest
+public sealed class GetAllToDosEndpointTests(NoPlanApiFactory factory) : FakeRequestTest(factory)
 {
-    public GetAllToDosEndpointTests(NoPlanApiFactory factory)
-        : base(factory)
-    {
-    }
-
     [Fact]
     public async Task HandleAsync_ShouldReturn200AndToDos_WhenUserIsAuthenticated()
     {

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/GetToDoEndpointTests.cs
@@ -8,13 +8,8 @@ using NoPlan.Contracts.Responses.V1.ToDos;
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
 
 [UsesVerify]
-public sealed class GetToDoEndpointTests : FakeRequestTest
+public sealed class GetToDoEndpointTests(NoPlanApiFactory factory) : FakeRequestTest(factory)
 {
-    public GetToDoEndpointTests(NoPlanApiFactory factory)
-        : base(factory)
-    {
-    }
-
     [Fact]
     public async Task HandleAsync_ShouldReturn200AndToDos_WhenToDoExistsAndUserIsAuthenticated()
     {

--- a/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/UpdateToDoEndpointTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/Endpoints/V1/ToDos/UpdateToDoEndpointTests.cs
@@ -8,13 +8,8 @@ using NoPlan.Contracts.Responses.V1.ToDos;
 namespace NoPlan.Api.Tests.Integration.Endpoints.V1.ToDos;
 
 [UsesVerify]
-public sealed class UpdateToDoEndpointTests : FakeRequestTest
+public sealed class UpdateToDoEndpointTests(NoPlanApiFactory factory) : FakeRequestTest(factory)
 {
-    public UpdateToDoEndpointTests(NoPlanApiFactory factory)
-        : base(factory)
-    {
-    }
-
     [Fact]
     public async Task HandleAsync_ShouldReturn200AndToDos_WhenToDoExistsAndUserIsAuthenticated()
     {

--- a/tests/NoPlan.Api.Tests.Integration/HealthChecks/HealthyHealthCheckTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/HealthChecks/HealthyHealthCheckTests.cs
@@ -1,17 +1,12 @@
 ﻿namespace NoPlan.Api.Tests.Integration.HealthChecks;
 
-public sealed class HealthyHealthCheckTests : IClassFixture<NoPlanApiFactory>
+public sealed class HealthyHealthCheckTests(NoPlanApiFactory apiFactory) : IClassFixture<NoPlanApiFactory>
 {
-    private readonly NoPlanApiFactory _apiFactory;
-
-    public HealthyHealthCheckTests(NoPlanApiFactory apiFactory) =>
-        _apiFactory = apiFactory;
-
     [Fact]
     public async Task ReadinessProbe_ShouldReturn200_WhenAppIsHealthy()
     {
         // Arrange
-        var client = _apiFactory.CreateClient();
+        var client = apiFactory.CreateClient();
 
         // Act
         var response = await client.GetAsync("/health/ready");
@@ -24,7 +19,7 @@ public sealed class HealthyHealthCheckTests : IClassFixture<NoPlanApiFactory>
     public async Task LivenessProbe_ShouldReturn200_WhenAppIsHealthy()
     {
         // Arrange
-        var client = _apiFactory.CreateClient();
+        var client = apiFactory.CreateClient();
 
         // Act
         var response = await client.GetAsync("/health/live");

--- a/tests/NoPlan.Api.Tests.Integration/HealthChecks/UnhealthyHealthCheckTests.cs
+++ b/tests/NoPlan.Api.Tests.Integration/HealthChecks/UnhealthyHealthCheckTests.cs
@@ -1,18 +1,13 @@
 ﻿namespace NoPlan.Api.Tests.Integration.HealthChecks;
 
-public sealed class UnhealthyHealthCheckTests : IClassFixture<NoPlanApiFactory>
+public sealed class UnhealthyHealthCheckTests(NoPlanApiFactory apiFactory) : IClassFixture<NoPlanApiFactory>
 {
-    private readonly NoPlanApiFactory _apiFactory;
-
-    public UnhealthyHealthCheckTests(NoPlanApiFactory apiFactory) =>
-        _apiFactory = apiFactory;
-
     [Fact]
     public async Task ReadinessProbe_ShouldReturn503_WhenAppIsUnhealthy()
     {
         // Arrange
-        var client = _apiFactory.CreateClient();
-        await _apiFactory.ShutdownDatabaseAsync();
+        var client = apiFactory.CreateClient();
+        await apiFactory.ShutdownDatabaseAsync();
 
         // Act
         var response = await client.GetAsync("/health/ready");

--- a/tests/NoPlan.Api.Tests.Integration/TestBases/EndpointTestBase.cs
+++ b/tests/NoPlan.Api.Tests.Integration/TestBases/EndpointTestBase.cs
@@ -1,20 +1,15 @@
 ﻿namespace NoPlan.Api.Tests.Integration.TestBases;
 
-public class EndpointTestBase : IAsyncLifetime, IClassFixture<NoPlanApiFactory>
+public class EndpointTestBase(NoPlanApiFactory factory) : IAsyncLifetime, IClassFixture<NoPlanApiFactory>
 {
-    private readonly NoPlanApiFactory _factory;
-
-    public EndpointTestBase(NoPlanApiFactory factory) =>
-        _factory = factory;
-
     protected HttpClient AuthenticatedClientClient { get; private set; } = null!;
 
     protected HttpClient AnonymousClient { get; private set; } = null!;
 
     public async Task InitializeAsync()
     {
-        AuthenticatedClientClient = await _factory.AuthenticatedClient.Value;
-        AnonymousClient = _factory.CreateClient();
+        AuthenticatedClientClient = await factory.AuthenticatedClient.Value;
+        AnonymousClient = factory.CreateClient();
     }
 
     public Task DisposeAsync() =>

--- a/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/CreateTagRequestValidatorTests.cs
+++ b/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/CreateTagRequestValidatorTests.cs
@@ -5,10 +5,7 @@ namespace NoPlan.Api.Tests.Unit.Validators.V1.ToDos;
 
 public sealed class CreateTagRequestValidatorTests
 {
-    private readonly CreateTagRequestValidator _sut;
-
-    public CreateTagRequestValidatorTests() =>
-        _sut = new();
+    private readonly CreateTagRequestValidator _sut = new();
 
     [Fact]
     public void Validate_ShouldFail_WhenNameIsEmpty()

--- a/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/CreateToDoRequestValidatorTest.cs
+++ b/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/CreateToDoRequestValidatorTest.cs
@@ -6,10 +6,7 @@ namespace NoPlan.Api.Tests.Unit.Validators.V1.ToDos;
 
 public sealed class CreateToDoRequestValidatorTest : TestWithFakes
 {
-    private readonly CreateToDoRequestValidator _sut;
-
-    public CreateToDoRequestValidatorTest() =>
-        _sut = new();
+    private readonly CreateToDoRequestValidator _sut = new();
 
     [Fact]
     public void Validate_ShouldFail_WhenTitleIsEmpty()

--- a/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/DeleteToDoRequestValidatorTests.cs
+++ b/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/DeleteToDoRequestValidatorTests.cs
@@ -5,10 +5,7 @@ namespace NoPlan.Api.Tests.Unit.Validators.V1.ToDos;
 
 public sealed class DeleteToDoRequestValidatorTests
 {
-    private readonly DeleteToDoRequestValidator _sut;
-
-    public DeleteToDoRequestValidatorTests() =>
-        _sut = new();
+    private readonly DeleteToDoRequestValidator _sut = new();
 
     [Fact]
     public void Validate_ShouldFail_WhenIdIsEmpty()

--- a/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/GetToDoRequestValidatorTests.cs
+++ b/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/GetToDoRequestValidatorTests.cs
@@ -5,10 +5,7 @@ namespace NoPlan.Api.Tests.Unit.Validators.V1.ToDos;
 
 public sealed class GetToDoRequestValidatorTests
 {
-    private readonly GetToDoRequestValidator _sut;
-
-    public GetToDoRequestValidatorTests() =>
-        _sut = new();
+    private readonly GetToDoRequestValidator _sut = new();
 
     [Fact]
     public void Validate_ShouldFail_WhenIdIsEmpty()

--- a/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/UpdateTagRequestValidatorTests.cs
+++ b/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/UpdateTagRequestValidatorTests.cs
@@ -5,10 +5,7 @@ namespace NoPlan.Api.Tests.Unit.Validators.V1.ToDos;
 
 public sealed class UpdateTagRequestValidatorTests
 {
-    private readonly UpdateTagRequestValidator _sut;
-
-    public UpdateTagRequestValidatorTests() =>
-        _sut = new();
+    private readonly UpdateTagRequestValidator _sut = new();
 
     [Fact]
     public void Validate_ShouldFail_WhenNameIsEmpty()

--- a/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/UpdateToDoRequestValidatorTest.cs
+++ b/tests/NoPlan.Api.Tests.Unit/Validators/V1/ToDos/UpdateToDoRequestValidatorTest.cs
@@ -6,10 +6,7 @@ namespace NoPlan.Api.Tests.Unit.Validators.V1.ToDos;
 
 public sealed class UpdateToDoRequestValidatorTest : TestWithFakes
 {
-    private readonly UpdateToDoRequestValidator _sut;
-
-    public UpdateToDoRequestValidatorTest() =>
-        _sut = new();
+    private readonly UpdateToDoRequestValidator _sut = new();
 
     [Fact]
     public void Validate_ShouldFail_WhenIdIsEmpty()


### PR DESCRIPTION
Changed services to make use of the new .NET 8 primary constructors wherever possible.