### PR TITLE
refactor(mapping): extracted mapping logic to extension methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,7 +371,6 @@ FodyWeavers.xsd
 
 # globs
 Makefile.in
-*.userprefs
 *.usertasks
 config.make
 config.status

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,10 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.6.23329.11"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-preview.6.23329.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-preview.6.23329.4"/>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.6.23329.4"/>
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-preview.6.23329.7"/>
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.0-preview.6.23329.7"/>

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/DeleteToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/DeleteToDoEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http.HttpResults;
 using NoPlan.Api.Features.ToDos;
+using NoPlan.Api.Mappers;
 using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
-using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
@@ -20,25 +20,8 @@ public sealed class DeleteToDoEndpoint(IToDoService toDoService) : Endpoint<Dele
         ArgumentNullException.ThrowIfNull(req);
 
         var deletedToDo = await toDoService.DeleteAsync(req.Id, User.GetId());
-        if (deletedToDo is null)
-        {
-            return TypedResults.NotFound();
-        }
-
-        return TypedResults.Ok(MapFromEntity(deletedToDo));
-    }
-
-    private static ToDoResponse MapFromEntity(ToDo e)
-    {
-        ArgumentNullException.ThrowIfNull(e);
-
-        return new()
-        {
-            Id = e.Id,
-            Title = e.Title,
-            Description = e.Description,
-            Tags = e.Tags.Select(ta => new TagResponse { Id = ta.Id, Name = ta.Name, AssignedAt = ta.AssignedAt }),
-            CreatedAt = e.CreatedAt
-        };
+        return deletedToDo is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(deletedToDo.ToResponse());
     }
 }

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/GetAllToDosEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/GetAllToDosEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http.HttpResults;
 using NoPlan.Api.Features.ToDos;
+using NoPlan.Api.Mappers;
 using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
-using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
@@ -16,18 +16,5 @@ public sealed class GetAllToDosEndpoint(IToDoService toDoService) : Endpoint<Get
     }
 
     public override async Task<Ok<ToDosResponse>> ExecuteAsync(GetAllToDosRequest req, CancellationToken ct) =>
-        TypedResults.Ok(MapFromEntity(await toDoService.GetAllAsync(User.GetId(), ct)));
-
-    private static ToDosResponse MapFromEntity(IEnumerable<ToDo> e) => new()
-    {
-        ToDos = e.Select(t =>
-            new ToDoResponse
-            {
-                Id = t.Id,
-                Title = t.Title,
-                Description = t.Description,
-                Tags = t.Tags.Select(ta => new TagResponse { Id = ta.Id, Name = ta.Name, AssignedAt = ta.AssignedAt }),
-                CreatedAt = t.CreatedAt
-            })
-    };
+        TypedResults.Ok((await toDoService.GetAllAsync(User.GetId(), ct)).ToResponse());
 }

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/GetToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/GetToDoEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http.HttpResults;
 using NoPlan.Api.Features.ToDos;
+using NoPlan.Api.Mappers;
 using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
-using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
@@ -21,24 +21,8 @@ public sealed class GetToDoEndpoint(IToDoService toDoService) : Endpoint<GetToDo
         ArgumentNullException.ThrowIfNull(req);
 
         var todo = await toDoService.GetAsync(req.Id, User.GetId(), ct);
-        if (todo is null)
-        {
-            return TypedResults.NotFound();
-        }
-
-        return TypedResults.Ok(MapFromEntity(todo));
-    }
-
-    private static ToDoResponse MapFromEntity(ToDo e)
-    {
-        ArgumentNullException.ThrowIfNull(e);
-        return new()
-        {
-            Id = e.Id,
-            Title = e.Title,
-            Description = e.Description,
-            Tags = e.Tags.Select(ta => new TagResponse { Id = ta.Id, Name = ta.Name, AssignedAt = ta.AssignedAt }),
-            CreatedAt = e.CreatedAt
-        };
+        return todo is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(todo.ToResponse());
     }
 }

--- a/src/NoPlan.Api/Endpoints/V1/ToDos/UpdateToDoEndpoint.cs
+++ b/src/NoPlan.Api/Endpoints/V1/ToDos/UpdateToDoEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http.HttpResults;
 using NoPlan.Api.Features.ToDos;
+using NoPlan.Api.Mappers;
 using NoPlan.Contracts.Requests.V1.ToDos;
 using NoPlan.Contracts.Responses.V1.ToDos;
-using NoPlan.Infrastructure.Data.Models;
 
 namespace NoPlan.Api.Endpoints.V1.ToDos;
 
@@ -18,46 +18,9 @@ public sealed class UpdateToDoEndpoint(IToDoService toDoService, TimeProvider cl
 
     public override async Task<Results<Ok<ToDoResponse>, NotFound>> ExecuteAsync(UpdateToDoRequest req, CancellationToken ct)
     {
-        var updatedToDo = await toDoService.UpdateAsync(MapToEntity(req));
-        if (updatedToDo is null)
-        {
-            return TypedResults.NotFound();
-        }
-
-        return TypedResults.Ok(MapFromEntity(updatedToDo));
-    }
-
-    private static Tag MapToEntity(UpdateTagRequest r, DateTime updateTime) =>
-        new() { Id = r.Id, Name = r.Name, AssignedAt = updateTime };
-
-    private static ToDoResponse MapFromEntity(ToDo e)
-    {
-        ArgumentNullException.ThrowIfNull(e);
-
-        return new()
-        {
-            Id = e.Id,
-            Title = e.Title,
-            Description = e.Description,
-            Tags = e.Tags.Select(MapFromEntity),
-            CreatedAt = e.CreatedAt
-        };
-    }
-
-    private static TagResponse MapFromEntity(Tag e) =>
-        new() { Id = e.Id, Name = e.Name, AssignedAt = e.AssignedAt };
-
-    private ToDo MapToEntity(UpdateToDoRequest r)
-    {
-        ArgumentNullException.ThrowIfNull(r);
-        var updateTime = clock.GetUtcNow().DateTime;
-        return new()
-        {
-            Id = r.Id,
-            Title = r.Title,
-            Description = r.Description,
-            Tags = r.Tags.Select(request => MapToEntity(request, updateTime)).ToList(),
-            CreatedBy = User.GetId()
-        };
+        var updatedToDo = await toDoService.UpdateAsync(req.ToEntity(clock.GetUtcNow().DateTime, User.GetId()));
+        return updatedToDo is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(updatedToDo.ToResponse());
     }
 }

--- a/src/NoPlan.Api/Mappers/TagMappers.cs
+++ b/src/NoPlan.Api/Mappers/TagMappers.cs
@@ -1,0 +1,29 @@
+﻿using NoPlan.Contracts.Requests.V1.ToDos;
+using NoPlan.Contracts.Responses.V1.ToDos;
+using NoPlan.Infrastructure.Data.Models;
+
+namespace NoPlan.Api.Mappers;
+
+public static class TagMappers
+{
+    public static TagResponse ToResponse(this Tag tag)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+
+        return new() { Id = tag.Id, Name = tag.Name, AssignedAt = tag.AssignedAt };
+    }
+
+    public static Tag ToEntity(this CreateTagRequest request, DateTime creationTime)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new() { Name = request.Name, AssignedAt = creationTime };
+    }
+
+    public static Tag ToEntity(this UpdateTagRequest r, DateTime updateTime)
+    {
+        ArgumentNullException.ThrowIfNull(r);
+
+        return new() { Id = r.Id, Name = r.Name, AssignedAt = updateTime };
+    }
+}

--- a/src/NoPlan.Api/Mappers/ToDoMappers.cs
+++ b/src/NoPlan.Api/Mappers/ToDoMappers.cs
@@ -1,0 +1,38 @@
+﻿using NoPlan.Contracts.Requests.V1.ToDos;
+using NoPlan.Contracts.Responses.V1.ToDos;
+using NoPlan.Infrastructure.Data.Models;
+
+namespace NoPlan.Api.Mappers;
+
+public static class ToDoMappers
+{
+    public static ToDoResponse ToResponse(this ToDo toDo)
+    {
+        ArgumentNullException.ThrowIfNull(toDo);
+
+        return new()
+        {
+            Id = toDo.Id,
+            Title = toDo.Title,
+            Description = toDo.Description,
+            Tags = toDo.Tags.Select(t => t.ToResponse()),
+            CreatedAt = toDo.CreatedAt
+        };
+    }
+
+    public static ToDosResponse ToResponse(this IEnumerable<ToDo> toDos) =>
+        new() { ToDos = toDos.Select(t => t.ToResponse()) };
+
+    public static ToDo ToEntity(this UpdateToDoRequest request, DateTime updateTime, Guid creatorId)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new()
+        {
+            Id = request.Id,
+            Title = request.Title,
+            Description = request.Description,
+            Tags = request.Tags.Select(tagRequest => tagRequest.ToEntity(updateTime)).ToList(),
+            CreatedBy = creatorId
+        };
+    }
+}

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -1,8 +1,7 @@
-using System.Diagnostics;
 using FastEndpoints.Swagger;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Identity.Web;
 using NoPlan.Api.Features.ToDos;
+using NoPlan.Api.Validation;
 using NoPlan.Infrastructure.Data;
 using NoPlan.Infrastructure.HeathChecks;
 
@@ -35,24 +34,7 @@ await new MigrationRunner(app.Services).ApplyMigrationsAsync<PlannerContext>();
 app.UseFastEndpoints(c =>
 {
     c.Endpoints.RoutePrefix = "api";
-
-    c.Errors.ResponseBuilder = (failures, context, status) =>
-    {
-        var problemDetails = new ValidationProblemDetails
-        {
-            Type = "https://www.rfc-editor.org/rfc/rfc7231#section-6.5.1",
-            Status = status,
-            Extensions = { ["traceId"] = Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier }
-        };
-
-        foreach (var failure in failures.GroupBy(f => f.PropertyName))
-        {
-            problemDetails.Errors[failure.Key] = failure.Select(g => g.ErrorMessage).ToArray();
-        }
-
-        return problemDetails;
-    };
-
+    c.Errors.ResponseBuilder = ValidationErrors.ResponseBuilder;
     c.Versioning.Prefix = "v";
     c.Versioning.DefaultVersion = 1;
     c.Versioning.PrependToRoute = true;

--- a/src/NoPlan.Api/Validation/ValidationErrors.cs
+++ b/src/NoPlan.Api/Validation/ValidationErrors.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NoPlan.Api.Validation;
+
+public static class ValidationErrors
+{
+#pragma warning disable CA1002
+    public static object ResponseBuilder(List<ValidationFailure> failures, HttpContext context, int status)
+#pragma warning restore CA1002
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var problemDetails = new ValidationProblemDetails
+        {
+            Type = "https://www.rfc-editor.org/rfc/rfc7231#section-6.5.1",
+            Status = status,
+            Extensions = { ["traceId"] = Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier }
+        };
+
+        foreach (var failure in failures.GroupBy(f => f.PropertyName))
+        {
+            problemDetails.Errors[failure.Key] = failure.Select(g => g.ErrorMessage).ToArray();
+        }
+
+        return problemDetails;
+    }
+}


### PR DESCRIPTION
Moved the mapping logic from the individual endpoints to extension methods. This was done to reduce the complexity, reduce code duplication and improve the maintainability of the codebase.

Also, removed the duplicate `userprefs` from `.gitignore`.

 Furthermore, the `ValidationErrors.ResponseBuilder` method was extracted to another class to enhance code readability and segregation.