### PR TITLE
refactor: Optimize telemetry for development environment

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,35 +5,35 @@
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.7" />
-    <PackageVersion Include="Bogus" Version="34.0.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="FastEndpoints" Version="5.17.1.1" />
-    <PackageVersion Include="FastEndpoints.Generator" Version="5.17.1.1" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="5.17.1.1" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0"/>
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.7"/>
+    <PackageVersion Include="Bogus" Version="34.0.2"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.0"/>
+    <PackageVersion Include="FastEndpoints" Version="5.17.1.1"/>
+    <PackageVersion Include="FastEndpoints.Generator" Version="5.17.1.1"/>
+    <PackageVersion Include="FastEndpoints.Swagger" Version="5.17.1.1"/>
+    <PackageVersion Include="FluentAssertions" Version="6.12.0"/>
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29"/>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-rc.1.23419.6"/>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-rc.1.23419.6"/>
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-rc.1.23419.4"/>
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.0-rc.1.23419.4"/>
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.56.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="2.13.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.5.0-rc.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.0.0-alpha.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
-    <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.10.0.77988" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="3.5.0" />
-    <PackageVersion Include="Verify.Xunit" Version="21.2.0" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.56.0"/>
+    <PackageVersion Include="Microsoft.Identity.Web" Version="2.13.4"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1"/>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.5.1-alpha.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1"/>
+    <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.10.0.77988"/>
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507"/>
+    <PackageVersion Include="Testcontainers.MsSql" Version="3.5.0"/>
+    <PackageVersion Include="Verify.Xunit" Version="21.2.0"/>
+    <PackageVersion Include="xunit" Version="2.5.1"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1"/>
   </ItemGroup>
 </Project>

--- a/src/NoPlan.Api/NoPlan.Api.csproj
+++ b/src/NoPlan.Api/NoPlan.Api.csproj
@@ -10,25 +10,25 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FastEndpoints.Swagger" />
+    <PackageReference Include="FastEndpoints.Swagger"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FastEndpoints" />
+    <Using Include="FastEndpoints"/>
     <Using Include="NoPlan.Infrastructure.Auth"/>
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="appsettings.Development.json" CopyToPublishDirectory="Never" />
+    <None Include="appsettings.Development.json" CopyToPublishDirectory="Never"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NoPlan.Contracts\NoPlan.Contracts.csproj" />
-    <ProjectReference Include="..\NoPlan.Infrastructure\NoPlan.Infrastructure.csproj" />
+    <ProjectReference Include="..\NoPlan.Contracts\NoPlan.Contracts.csproj"/>
+    <ProjectReference Include="..\NoPlan.Infrastructure\NoPlan.Infrastructure.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/NoPlan.Contracts/NoPlan.Contracts.csproj
+++ b/src/NoPlan.Contracts/NoPlan.Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" />
+    <PackageReference Include="FastEndpoints"/>
     <PackageReference Include="FastEndpoints.Generator">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FastEndpoints" />
-    <Using Include="FluentValidation" />
+    <Using Include="FastEndpoints"/>
+    <Using Include="FluentValidation"/>
   </ItemGroup>
 </Project>

--- a/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
+++ b/src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Identity.Web" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EventCounters" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer"/>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
+    <PackageReference Include="Microsoft.Identity.Web"/>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.EventCounters"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Microsoft.EntityFrameworkCore" />
-    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.EntityFrameworkCore"/>
+    <Using Include="Microsoft.Extensions.Configuration"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Changes

- Enhanced the telemetry configuration in `WebApplicationBuilderExtensions.cs` to only  register the OpenTelemetry Exporter during development