### PR TITLE
chore(infra): replaced deprecated properties in the `azuread` provider

### DIFF
--- a/infra/global/applications.tf
+++ b/infra/global/applications.tf
@@ -73,7 +73,7 @@ resource "azuread_application" "integration_testing" {
   }
 
   required_resource_access {
-    resource_app_id = azuread_application.api.application_id
+    resource_app_id = azuread_application.api.client_id
     resource_access {
       id   = local.api_user_scope_id
       type = "Scope"
@@ -82,7 +82,7 @@ resource "azuread_application" "integration_testing" {
 }
 
 resource "azuread_service_principal" "api" {
-  application_id               = azuread_application.api.application_id
+  client_id                    = azuread_application.api.client_id
   app_role_assignment_required = false
   owners = [
     data.azuread_client_config.current.object_id
@@ -90,7 +90,7 @@ resource "azuread_service_principal" "api" {
 }
 
 resource "azuread_service_principal" "integration_testing" {
-  application_id               = azuread_application.integration_testing.application_id
+  client_id                    = azuread_application.integration_testing.client_id
   app_role_assignment_required = false
   owners = [
     data.azuread_client_config.current.object_id
@@ -98,6 +98,6 @@ resource "azuread_service_principal" "integration_testing" {
 }
 
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
 }

--- a/infra/global/outputs.tf
+++ b/infra/global/outputs.tf
@@ -1,5 +1,5 @@
-output "api_application_id" {
-  value = azuread_application.api.application_id
+output "api_client_id" {
+  value = azuread_application.api.client_id
 }
 
 output "api_audience" {
@@ -26,8 +26,8 @@ output "default_domain" {
   value = data.azuread_domains.default_domain.domains.0.domain_name
 }
 
-output "integration_testing_application_id" {
-  value = azuread_application.integration_testing.application_id
+output "integration_testing_client_id" {
+  value = azuread_application.integration_testing.client_id
 }
 
 output "subscription_id" {

--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -6,7 +6,7 @@ data "tfe_outputs" "global" {
 }
 
 locals {
-  api_application_id      = nonsensitive(data.tfe_outputs.global.values.api_application_id)
+  api_client_id           = nonsensitive(data.tfe_outputs.global.values.api_client_id)
   api_audience            = nonsensitive(data.tfe_outputs.global.values.api_audience)
   default_domain          = nonsensitive(data.tfe_outputs.global.values.default_domain)
   api_tenant_id           = nonsensitive(data.tfe_outputs.global.values.api_tenant_id)
@@ -17,7 +17,7 @@ module "container_app" {
   source                                = "../modules/containerapp"
   application_insights_connectionstring = module.monitoring.app_insights_connection_string
   azure_ad_audience                     = local.api_audience
-  azure_ad_client_id                    = local.api_application_id
+  azure_ad_client_id                    = local.api_client_id
   azure_ad_domain                       = local.default_domain
   azure_ad_instance                     = var.azure_ad_instance
   azure_ad_tenant_id                    = local.api_tenant_id

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -6,7 +6,7 @@ data "tfe_outputs" "global" {
 }
 
 locals {
-  api_application_id      = nonsensitive(data.tfe_outputs.global.values.api_application_id)
+  api_client_id           = nonsensitive(data.tfe_outputs.global.values.api_client_id)
   api_audience            = nonsensitive(data.tfe_outputs.global.values.api_audience)
   default_domain          = nonsensitive(data.tfe_outputs.global.values.default_domain)
   api_tenant_id           = nonsensitive(data.tfe_outputs.global.values.api_tenant_id)
@@ -17,7 +17,7 @@ module "container_app" {
   source                                = "../modules/containerapp"
   application_insights_connectionstring = module.monitoring.app_insights_connection_string
   azure_ad_audience                     = local.api_audience
-  azure_ad_client_id                    = local.api_application_id
+  azure_ad_client_id                    = local.api_client_id
   azure_ad_domain                       = local.default_domain
   azure_ad_instance                     = var.azure_ad_instance
   azure_ad_tenant_id                    = local.api_tenant_id


### PR DESCRIPTION
Replaced the now deprecated `application_id` property with `client_id` and renamed relevant `locals` and `outputs`.