### PR TITLE
feat(containers): moved to chiseled base image with i18n features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
+          global-json-file: global.json
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
-          dotnet-quality: preview
+          global-json-file: global.json
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra AS base
 WORKDIR /app
 EXPOSE 8080
 
@@ -17,12 +17,12 @@ COPY ["src/NoPlan.Infrastructure/", "src/NoPlan.Infrastructure/"]
 # Copy the git repository data for Source Link
 COPY [".git/", ".git/"]
 WORKDIR /app/src/NoPlan.Api
-RUN dotnet build --no-restore -c Release -r linux-x64 --no-self-contained "NoPlan.Api.csproj"
+RUN dotnet build --no-restore -c Release -r linux-x64 --sc "NoPlan.Api.csproj"
 
 FROM build AS publish
-RUN dotnet publish --no-build -r linux-x64 --no-self-contained -o /app/publish "NoPlan.Api.csproj"
+RUN dotnet publish --no-build -r linux-x64 --sc -o /app/publish "NoPlan.Api.csproj"
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "NoPlan.Api.dll"]
+ENTRYPOINT ["./NoPlan.Api"]

--- a/NoPlan.sln
+++ b/NoPlan.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\renovate.json = .github\renovate.json
 		.github\CODEOWNERS = .github\CODEOWNERS
 		nuget.config = nuget.config
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoPlan.Infrastructure", "src\NoPlan.Infrastructure\NoPlan.Infrastructure.csproj", "{7148D0A0-C3D5-4807-99D3-E4AB88875F03}"

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.100-rc.2.23502.2",
+    "allowPrerelease": true,
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/NoPlan.Api/Features/ToDos/ToDoService.cs
+++ b/src/NoPlan.Api/Features/ToDos/ToDoService.cs
@@ -15,11 +15,17 @@ public sealed class ToDoService(PlannerContext context) : IToDoService
 {
     /// <inheritdoc />
     public async Task<IEnumerable<ToDo>> GetAllAsync(Guid userId, CancellationToken cancellationToken = default) =>
-        await context.ToDos.Include(t => t.Tags).OrderByDescending(t => t.CreatedAt).AsNoTracking().ToListAsync(cancellationToken);
+        await context.ToDos
+            .Include(t => t.Tags)
+            .OrderByDescending(t => t.CreatedAt)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
 
     /// <inheritdoc />
     public async Task<ToDo?> GetAsync(Guid id, Guid userId, CancellationToken cancellationToken = default) =>
-        await context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        await context.ToDos
+            .Include(t => t.Tags)
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
 
     /// <inheritdoc />
     public async Task<ToDo> CreateAsync(ToDo newToDo)
@@ -37,7 +43,10 @@ public sealed class ToDoService(PlannerContext context) : IToDoService
     {
         ArgumentNullException.ThrowIfNull(updatedToDo);
 
-        var toDo = await context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == updatedToDo.Id);
+        var toDo = await context.ToDos
+            .Include(t => t.Tags)
+            .FirstOrDefaultAsync(t => t.Id == updatedToDo.Id);
+
         if (toDo is null)
         {
             return null;
@@ -62,7 +71,10 @@ public sealed class ToDoService(PlannerContext context) : IToDoService
     /// <inheritdoc />
     public async Task<ToDo?> DeleteAsync(Guid id, Guid userId)
     {
-        var toDo = await context.ToDos.Include(t => t.Tags).FirstOrDefaultAsync(t => t.Id == id);
+        var toDo = await context.ToDos
+            .Include(t => t.Tags)
+            .FirstOrDefaultAsync(t => t.Id == id);
+
         if (toDo is null)
         {
             return null;

--- a/src/NoPlan.Api/Program.cs
+++ b/src/NoPlan.Api/Program.cs
@@ -64,4 +64,5 @@ try
 catch (Exception ex)
 {
     bootStrapLogger.LogCritical(ex, "The application shut down unexpectedly");
+    throw;
 }


### PR DESCRIPTION
# Changes

- Switched base image to `runtime-deps` with `jammy-chiseled-extra` containing `tzdata` and `libicu`
- Adjusted `Dockerfile` to publish self-contained
- Added `global.json` to pin the .NET version and enable automated updates by renovate when newer image tags are released
- Added formatting to `ToDoService`
- Added `throw` statement in order for the application to shut down after logging a fatal exception