### PR TITLE
feat(docker): made Dockerfile platform agnostic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra AS base
 WORKDIR /app
 EXPOSE 8080
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG TARGETARCH
 WORKDIR /app
 COPY [".editorconfig", "Directory.Build.props", "Directory.Packages.props", "nuget.config", "./"]
 COPY ["src/Directory.Build.props", "src/"]
 COPY ["src/NoPlan.Api/NoPlan.Api.csproj", "src/NoPlan.Api/"]
 COPY ["src/NoPlan.Contracts/NoPlan.Contracts.csproj", "src/NoPlan.Contracts/"]
 COPY ["src/NoPlan.Infrastructure/NoPlan.Infrastructure.csproj", "src/NoPlan.Infrastructure/"]
-RUN dotnet restore -r linux-x64 "src/NoPlan.Api/NoPlan.Api.csproj"
+RUN dotnet restore -a $TARGETARCH "src/NoPlan.Api/NoPlan.Api.csproj"
 COPY ["src/NoPlan.Api/", "src/NoPlan.Api/"]
 COPY ["src/NoPlan.Contracts/", "src/NoPlan.Contracts/"]
 COPY ["src/NoPlan.Infrastructure/", "src/NoPlan.Infrastructure/"]
@@ -17,10 +18,10 @@ COPY ["src/NoPlan.Infrastructure/", "src/NoPlan.Infrastructure/"]
 # Copy the git repository data for Source Link
 COPY [".git/", ".git/"]
 WORKDIR /app/src/NoPlan.Api
-RUN dotnet build --no-restore -c Release -r linux-x64 --sc "NoPlan.Api.csproj"
+RUN dotnet build --no-restore -c Release -a $TARGETARCH --sc "NoPlan.Api.csproj"
 
 FROM build AS publish
-RUN dotnet publish --no-build -r linux-x64 --sc -o /app/publish "NoPlan.Api.csproj"
+RUN dotnet publish --no-build -a $TARGETARCH --sc -o /app/publish "NoPlan.Api.csproj"
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
By setting the `--platform` switch to `$BUILDPLATFORM` for the SDK image, building the app is guaranteed to work, even when a different `$TARGETPLATFORM` is specified. Using the new `--arch/-a` switch in conjunction with the `$TARGETARCH` variable provided by the build engine, enables a flexible self-contained deployment.