### PR TITLE
chore(terraform): remove hard-coded Terraform Cloud config

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -8,6 +8,12 @@ inputs:
   tf-api-token:
     description: 'The Terraform Cloud API token'
     required: true
+  tf-cloud-organization:
+    description: 'The name of the Terraform Cloud organization'
+    required: true
+  tf-cloud-workspace:
+    description: 'The name of the Terraform Cloud workspace'
+    required: true
   working-directory:
     description: 'The path to the Terraform working directory'
     required: true
@@ -15,6 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set Terraform Cloud environment variables
+      shell: bash
+      run: |
+        echo "TF_CLOUD_ORGANIZATION=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
+        echo "TF_WORKSPACE=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:

--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Set Terraform Cloud environment variables
       shell: bash
       run: |
-        echo "TF_CLOUD_ORGANIZATION=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
+        echo "TF_CLOUD_ORGANIZATION=${{ inputs.tf-cloud-organization }}" >> $GITHUB_ENV
         echo "TF_WORKSPACE=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -13,6 +13,12 @@ inputs:
   tf-api-token:
     description: 'The Terraform Cloud API token'
     required: true
+  tf-cloud-organization:
+    description: 'The name of the Terraform Cloud organization'
+    required: true
+  tf-cloud-workspace:
+    description: 'The name of the Terraform Cloud workspace'
+    required: true
   working-directory:
     description: 'The path to the Terraform working directory'
     required: true
@@ -20,6 +26,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set job environment variables
+      shell: bash
+      run: |
+        echo "TF_CLOUD_ORGANIZATION=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
+        echo "TF_WORKSPACE=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Set job environment variables
       shell: bash
       run: |
-        echo "TF_CLOUD_ORGANIZATION=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
+        echo "TF_CLOUD_ORGANIZATION=${{ inputs.tf-cloud-organization }}" >> $GITHUB_ENV
         echo "TF_WORKSPACE=${{ inputs.tf-cloud-workspace }}" >> $GITHUB_ENV
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/deploy-global-and-staging.yml
+++ b/.github/workflows/deploy-global-and-staging.yml
@@ -60,7 +60,9 @@ jobs:
         uses: ./.github/actions/terraform-apply
         with:
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
-          working-directory: ./infra/global
+          tf-cloud-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
+          tf-cloud-workspace: ${{ vars.TF_CLOUD_WORKSPACE }}
+          working-directory: ${{ vars.TF_WORKING_DIRECTORY }}
 
   apply-staging:
     name: Apply staging environment
@@ -77,4 +79,6 @@ jobs:
         with:
           image-name: ${{ env.IMAGE_NAME }}
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
-          working-directory: ./infra/staging
+          tf-cloud-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
+          tf-cloud-workspace: ${{ vars.TF_CLOUD_WORKSPACE }}
+          working-directory: ${{ vars.TF_WORKING_DIRECTORY }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,6 +37,7 @@ jobs:
 
   apply:
     name: Apply production environment
+    environment: production
     runs-on: ubuntu-latest
     needs:
       - promote-image
@@ -48,4 +49,6 @@ jobs:
         with:
           image-name: ${{ env.IMAGE_NAME }}
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
-          working-directory: ./infra/production
+          tf-cloud-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
+          tf-cloud-workspace: ${{ vars.TF_CLOUD_WORKSPACE }}
+          working-directory: ${{ vars.TF_WORKING_DIRECTORY }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -29,10 +29,11 @@ jobs:
         uses: ./.github/actions/terraform-validate
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: ./infra
+          working-directory: ${{ vars.INFRA_DIRECTORY}}
 
   plan-staging:
     name: Plan staging environment
+    environment: staging
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -44,10 +45,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: ${{ env.IMAGE_NAME }}
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
-          working-directory: ./infra/staging
+          tf-cloud-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
+          tf-cloud-workspace: ${{ vars.TF_CLOUD_WORKSPACE }}
+          working-directory: ${{ vars.TF_WORKING_DIRECTORY }}
 
   plan-production:
     name: Plan production environment
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -59,10 +63,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: ${{ env.IMAGE_NAME }}
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
-          working-directory: ./infra/production
+          tf-cloud-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
+          tf-cloud-workspace: ${{ vars.TF_CLOUD_WORKSPACE }}
+          working-directory: ${{ vars.TF_WORKING_DIRECTORY }}
 
   plan-global:
     name: Plan global environment
+    environment: global
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -73,4 +80,4 @@ jobs:
           environment-name: Global
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
-          working-directory: ./infra/global
+          working-directory: ${{ vars.TF_WORKING_DIRECTORY }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/terraform-validate
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: ${{ vars.INFRA_DIRECTORY}}
+          working-directory: ${{ vars.INFRA_DIRECTORY }}
 
   plan-staging:
     name: Plan staging environment
@@ -80,4 +80,6 @@ jobs:
           environment-name: Global
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tf-api-token: ${{ secrets.TF_API_TOKEN }}
+          tf-cloud-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
+          tf-cloud-workspace: ${{ vars.TF_CLOUD_WORKSPACE }}
           working-directory: ${{ vars.TF_WORKING_DIRECTORY }}

--- a/infra/global/providers.tf
+++ b/infra/global/providers.tf
@@ -15,13 +15,9 @@ terraform {
   }
 
   cloud {
-    organization = "ThorstenSauter"
-    workspaces {
-      name = "NoPlan-global"
-    }
   }
 
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.6.0"
 }
 
 provider "azuread" {}

--- a/infra/production/providers.tf
+++ b/infra/production/providers.tf
@@ -11,13 +11,9 @@ terraform {
   }
 
   cloud {
-    organization = "ThorstenSauter"
-    workspaces {
-      name = "NoPlan-production"
-    }
   }
 
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.6.0"
 }
 
 provider "azurerm" {

--- a/infra/staging/providers.tf
+++ b/infra/staging/providers.tf
@@ -11,13 +11,9 @@ terraform {
   }
 
   cloud {
-    organization = "ThorstenSauter"
-    workspaces {
-      name = "NoPlan-staging"
-    }
   }
 
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.6.0"
 }
 
 provider "azurerm" {


### PR DESCRIPTION
The configuration for Terraform Cloud has been refactored from being hard-coded in the infra provider files to being received as user inputs in the GitHub Actions workflows. The Terraform Cloud organization and workspace are now required inputs for the terraform-apply and terraform-plan actions. Additionally, the Terraform required version has been updated from `>= 1.4.0` to `>= 1.6.0`.