### PR TITLE
chore(deps): remove unused package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,12 +12,10 @@
     <PackageVersion Include="FastEndpoints" Version="5.20.1"/>
     <PackageVersion Include="FastEndpoints.Generator" Version="5.20.1"/>
     <PackageVersion Include="FluentAssertions" Version="6.12.0"/>
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0"/>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0"/>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.0"/>
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.58.0"/>
     <PackageVersion Include="Microsoft.Identity.Web" Version="2.16.0"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>

--- a/tests/NoPlan.Api.Tests.Unit/NoPlan.Api.Tests.Unit.csproj
+++ b/tests/NoPlan.Api.Tests.Unit/NoPlan.Api.Tests.Unit.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Bogus"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed `Microsoft.Extensions.DependencyModel` and `Microsoft.ApplicationInsights.AspNetCore` from the project as they were not in use.