### PR TITLE
chore(deps): Remove `Microsoft.SourceLink.GitHub` package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,6 @@
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.58.1"/>
     <PackageVersion Include="Microsoft.Identity.Web" Version="2.16.1"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
     <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.16.0.82469"/>
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,10 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="SecurityCodeScan.VS2019" Condition="$(MSBuildProjectExtension) == '.csproj'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The `Microsoft.SourceLink.GitHub` package was removed from `Directory.Build.props` and `Directory.Packages.props`, since it is now [included in the .NET SDK](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#source-link).