### PR TITLE
fix(.NET SDK): disable upgrade behaviour

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>NU1507;CS1591</NoWarn>
     <Authors>Thorsten Sauter</Authors>
-    <Copyright>(c) 2021-2023</Copyright>
+    <Copyright>(c) 2021-2024</Copyright>
     <RepositoryUrl>https://github.com/ThorstenSauter/NoPlan</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "8.0.101",
-    "rollForward": "latestMinor"
+    "version": "8.0.101"
   }
 }


### PR DESCRIPTION
# Changes

- Removed the `rollForward` behaviour in order to avoid thousands of `AD0001` analyzer errors when using a preview SDK
- Adjusted the copyright notice